### PR TITLE
Fix MentionReplySelectedMessage keybind in ui.go

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -203,7 +203,7 @@ func onMessagesViewInputCapture(e *tcell.EventKey) *tcell.EventKey {
 		messageInputField.SetTitle("Replying to " + m.Author.String())
 		app.SetFocus(messageInputField)
 		return nil
-	} else if util.HasKeybinding(conf.Keybindings.ReplySelectedMessage, e.Name()) {
+	} else if util.HasKeybinding(conf.Keybindings.MentionReplySelectedMessage, e.Name()) {
 		hs := messagesView.GetHighlights()
 		if len(hs) == 0 {
 			return nil


### PR DESCRIPTION
After commit e8a2f33, checking for MentionReplySelectedMessage keystroke incorrectly checked for ReplySelectedMessage instead.