### PR TITLE
Build via Docker and install in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ fmt:
 .PHONY: clean
 clean:
 	go clean
+
+.PHONY: install
+install:
+	sudo cp discordo /usr/local/bin

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+DOCKER=docker
+SOURCE_PATH := $(shell pwd)
+WORKING_PATH=/usr/src/myapp
+
+# Docker config
+DOCKER_RUN=$(DOCKER) run --rm -v $(SOURCE_PATH):$(WORKING_PATH) -w $(WORKING_PATH)
+
+# golang config
+GO_CONTAINER=golang:1.19
+GO=$(DOCKER_RUN) $(GO_CONTAINER) go
+GOFMT=$(DOCKER_RUN) $(GO_CONTAINER) gofmt
+
+.PHONY: build
+build:
+	$(GO) build -trimpath -buildmode=pie -ldflags "-s -w"
+
+.PHONY: test
+test:
+	$(GO) test 
+
+.PHONY: fmt
+fmt:
+	$(GOFMT) -d -e -s .
+
+.PHONY: clean
+clean:
+	$(GO) clean

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ git clone https://github.com/ayntgl/discordo
 cd discordo
 make build
 
+# Build using Docker, no need to install go
+make -f Makefile.docker build
+
 # optional
-sudo mv ./discordo /usr/local/bin
+make install
 ```
+
+
 
 ### Linux clipboard support
 


### PR DESCRIPTION
Allow building via Docker in order to by-pass installing go. Also added `install` to `Makefile`.