### PR TITLE
docs(README): add FreeBSD in Package manager section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can download and install a [prebuilt binary here](https://nightly.link/ayntg
 ### Package managers
 
 - [Arch Linux](https://aur.archlinux.org/packages/discordo-git/): `yay -S discordo-git` (thanks to [Alyxia Sother](https://github.com/lexisother) for maintaining the AUR package).
+- [FreeBSD](https://www.freshports.org/net-im/discordo): `pkg install discordo` or via the ports system `make -C /usr/ports/net-im/discordo install clean`.
 
 ### Building from source
 


### PR DESCRIPTION
I've committed `discordo` to the FreeBSD ports repository in [4747d3fc](https://cgit.freebsd.org/ports/commit/?id=4747d3fcdd2520f83b1274ba1e25087f031d4371), so added the corresponding instructions to install through either the FreeBSD package manager or ports collection in the README.