### PR TITLE
Use group chat name, with join usernames as a fallback only!

### DIFF
--- a/ui/util.go
+++ b/ui/util.go
@@ -35,12 +35,16 @@ func channelToString(c discord.Channel) string {
 		rp := c.DMRecipients[0]
 		repr = rp.Username + "#" + rp.Discriminator
 	case discord.GroupDM:
-		rps := make([]string, len(c.DMRecipients))
-		for i, r := range c.DMRecipients {
-			rps[i] = r.Username + "#" + r.Discriminator
+		repr = c.Name
+		// if the name wasn't loaded, use it as a backup
+		if repr == "" {
+			rps := make([]string, len(c.DMRecipients))
+			for i, r := range c.DMRecipients {
+				rps[i] = r.Username + "#" + r.Discriminator
+			}
+	
+			repr = strings.Join(rps, ", ")
 		}
-
-		repr = strings.Join(rps, ", ")
 	default:
 		repr = c.Name
 	}


### PR DESCRIPTION
The group chat name is sometimes available, why not use it?