### PR TITLE
Fix scroll

### DIFF
--- a/ui/actions_view.go
+++ b/ui/actions_view.go
@@ -96,12 +96,6 @@ func (v *ActionsView) mentionReplyAction() {
 }
 
 func (v *ActionsView) selectReplyAction() {
-	ms, err := v.core.State.Cabinet.Messages(v.message.ChannelID)
-	if err != nil {
-		return
-	}
-
-	v.core.MessagesView.selectedMessage, _ = findMessageByID(ms, v.message.ReferencedMessage.ID)
 	v.core.MessagesView.
 		Highlight(v.message.ReferencedMessage.ID.String()).
 		ScrollToHighlight()

--- a/ui/channels_view.go
+++ b/ui/channels_view.go
@@ -34,7 +34,6 @@ func newChannelsView(c *Core) *ChannelsView {
 
 func (v *ChannelsView) onSelected(node *tview.TreeNode) {
 	v.selectedChannel = nil
-	v.core.MessagesView.selectedMessage = -1
 	v.core.MessagesView.
 		Highlight().
 		Clear().

--- a/ui/guilds_view.go
+++ b/ui/guilds_view.go
@@ -33,7 +33,6 @@ func newGuildsView(c *Core) *GuildsView {
 
 func (v *GuildsView) onSelected(node *tview.TreeNode) {
 	v.core.ChannelsView.selectedChannel = nil
-	v.core.MessagesView.selectedMessage = -1
 	rootNode := v.core.ChannelsView.GetRoot()
 	rootNode.ClearChildren()
 	v.core.MessagesView.

--- a/ui/input_view.go
+++ b/ui/input_view.go
@@ -50,7 +50,6 @@ func (v *InputView) inputCapture(event *tcell.EventKey) *tcell.EventKey {
 		v.
 			SetText("").
 			SetTitle("")
-		v.core.MessagesView.selectedMessage = -1
 		v.core.MessagesView.Highlight()
 		return nil
 	}
@@ -95,7 +94,6 @@ func (v *InputView) sendMessage() *tcell.EventKey {
 
 		go v.core.State.SendMessageComplex(m.ChannelID, d)
 
-		v.core.MessagesView.selectedMessage = -1
 		v.core.MessagesView.Highlight()
 
 		v.SetTitle("")

--- a/ui/util.go
+++ b/ui/util.go
@@ -35,12 +35,16 @@ func channelToString(c discord.Channel) string {
 		rp := c.DMRecipients[0]
 		repr = rp.Username + "#" + rp.Discriminator
 	case discord.GroupDM:
-		rps := make([]string, len(c.DMRecipients))
-		for i, r := range c.DMRecipients {
-			rps[i] = r.Username + "#" + r.Discriminator
+		repr = c.Name
+		// if the name wasn't loaded, use it as a backup
+		if repr == "" {
+			rps := make([]string, len(c.DMRecipients))
+			for i, r := range c.DMRecipients {
+				rps[i] = r.Username + "#" + r.Discriminator
+			}
+	
+			repr = strings.Join(rps, ", ")
 		}
-
-		repr = strings.Join(rps, ", ")
 	default:
 		repr = c.Name
 	}


### PR DESCRIPTION
This PR fixes the message scroll. Before, it used to panic whenever it arrow keys were pressed

It removes the `MessageView.selectedMessage`, which while being an efficient method in theory, caused problems since it wasn't set anywhere. 
The new method uses `selInd` (selected Index) as a local variable, which is fetched from the highlighted region's ID. Admittedly, this means it loops over all the messages every time, but I don't see it as a problem since its not done over an array of 100000 elements. I believe that maximum that this project stores is about 100.