### PR TITLE
fix: panic on <down> key

### DIFF
--- a/cmd/run/messages_text.go
+++ b/cmd/run/messages_text.go
@@ -188,6 +188,8 @@ func (mt *MessagesText) selectPreviousAction() {
 	} else {
 		if mt.selectedMessage < len(ms)-1 {
 			mt.selectedMessage++
+		} else {
+			return
 		}
 	}
 
@@ -208,11 +210,9 @@ func (mt *MessagesText) selectNextAction() {
 	} else {
 		if mt.selectedMessage > 0 {
 			mt.selectedMessage--
+		} else {
+			return
 		}
-	}
-
-	if mt.selectedMessage < 0 {
-		return
 	}
 
 	mt.Highlight(ms[mt.selectedMessage].ID.String())

--- a/cmd/run/messages_text.go
+++ b/cmd/run/messages_text.go
@@ -211,6 +211,10 @@ func (mt *MessagesText) selectNextAction() {
 		}
 	}
 
+	if mt.selectedMessage < 0 {
+		return
+	}
+
 	mt.Highlight(ms[mt.selectedMessage].ID.String())
 	mt.ScrollToHighlight()
 }


### PR DESCRIPTION
```
panic: runtime error: index out of range [-1] [recovered]
        panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/rivo/tview.(*Application).Run.func1()
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/application.go:251 +0x4d
panic({0x9a89a0, 0xc0011a8000})
        /usr/lib/go/src/runtime/panic.go:884 +0x213
github.com/ayn2op/discordo/cmd/run.(*MessagesText).selectNextAction(0xc0000999c0)
        /home/proullon/.cache/yay/discordo-git/src/discordo/cmd/run/messages_text.go:214 +0x2d2
github.com/ayn2op/discordo/cmd/run.(*MessagesText).onInputCapture(0x100c000f3c701?, 0xc00015d198?)
        /home/proullon/.cache/yay/discordo-git/src/discordo/cmd/run/messages_text.go:129 +0x2b4
github.com/rivo/tview.(*Box).WrapInputHandler.func1(0x0?, 0xc00015d1f0?)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/box.go:164 +0x3a
github.com/rivo/tview.(*Flex).InputHandler.func1(0xc00015d230?, 0x7e0f5f?)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/flex.go:251 +0xd9
github.com/rivo/tview.(*Box).WrapInputHandler.func1(0xc000436870?, 0x967840?)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/box.go:167 +0x53
github.com/rivo/tview.(*Flex).InputHandler.func1(0x40f907?, 0x10?)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/flex.go:251 +0xd9
github.com/rivo/tview.(*Box).WrapInputHandler.func1(0xc00015d3e8?, 0xc00015d328?)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/box.go:167 +0x53
github.com/rivo/tview.(*Application).Run(0xc00024a380)
        /home/proullon/go/pkg/mod/github.com/rivo/tview@v0.0.0-20230621164836-6cc0565babaf/application.go:344 +0x57d
github.com/ayn2op/discordo/cmd/run.(*Cmd).Run(0xe4fa80)
        /home/proullon/.cache/yay/discordo-git/src/discordo/cmd/run/run.go:76 +0x1f7
reflect.Value.call({0x93ec40?, 0xe4fa80?, 0x8d813a?}, {0x9ebb8f, 0x4}, {0xc00015db70, 0x0, 0x491f34?})
        /usr/lib/go/src/reflect/value.go:586 +0xb0b
reflect.Value.Call({0x93ec40?, 0xe4fa80?, 0x957ae0?}, {0xc00015db70?, 0xc00015dbb8?, 0x40f52a?})
        /usr/lib/go/src/reflect/value.go:370 +0xbc
github.com/alecthomas/kong.callFunction({0x93ec40?, 0xe4fa80?, 0x55615c?}, 0x0?)
        /home/proullon/go/pkg/mod/github.com/alecthomas/kong@v0.8.0/callbacks.go:98 +0x445
github.com/alecthomas/kong.callMethod({0x9eb871, 0x3}, {0x9837e0?, 0xe4fa80?, 0x3?}, {0x93ec40?, 0xe4fa80?, 0x0?}, 0x0?)
        /home/proullon/go/pkg/mod/github.com/alecthomas/kong@v0.8.0/callbacks.go:132 +0x76
github.com/alecthomas/kong.(*Context).RunNode(0xc0000b6580, 0xc0000ca0f0, {0x0, 0x0, 0x0})
        /home/proullon/go/pkg/mod/github.com/alecthomas/kong@v0.8.0/context.go:762 +0x60f
github.com/alecthomas/kong.(*Context).Run(0x912060?, {0x0?, 0xc00015df60?, 0x7?})
        /home/proullon/go/pkg/mod/github.com/alecthomas/kong@v0.8.0/context.go:787 +0x14e
main.main()
        /home/proullon/.cache/yay/discordo-git/src/discordo/main.go:24 +0x197
 ```