### PR TITLE
Add different color for own messages

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -104,7 +104,11 @@ func (mt *MessagesText) createHeader(w io.Writer, m discord.Message, isReply boo
 		fmt.Fprintf(mt, "[::d]%s", cfg.Theme.MessagesText.ReplyIndicator)
 	}
 
-	fmt.Fprintf(w, "[%s]%s[-:-:-] ", cfg.Theme.MessagesText.AuthorColor, m.Author.Username)
+	var authorcolor = cfg.Theme.MessagesText.AuthorColor
+	if cfg.Theme.MessagesText.OwnAuthorName == m.Author.Username {
+		authorcolor = cfg.Theme.MessagesText.OwnAuthorColor
+	}
+	fmt.Fprintf(w, "[%s]%s[-:-:-] ", authorcolor, m.Author.Username)
 
 	if cfg.Timestamps && !cfg.TimestampsBeforeAuthor {
 		fmt.Fprintf(w, "[::d]%s[::-] ", time)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,8 @@ type Config struct {
 		MessagesText struct {
 			AuthorColor    string `yaml:"author_color"`
 			ReplyIndicator string `yaml:"reply_indicator"`
+			OwnAuthorName  string `yaml:"own_author_name"`
+			OwnAuthorColor string `yaml:"own_author_color"`
 		} `yaml:"messages_text"`
 	} `yaml:"theme"`
 }


### PR DESCRIPTION
I saw a similar feature requested in #329. For me, it would be enough to see my own messages, as it more easily allows me to check if there's something new. I didn't immediately find a way
to get the username from state, so I added it as a settings entry.

I didn't add to the documentation yet, because I would like to wait for feedback - if this sounds good, I'll make sure to update it.