### PR TITLE
Unselect messages after last one

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -218,19 +218,20 @@ func (mt *MessagesText) selectNextAction() {
 		return
 	}
 
-	// If no message is currently selected, select the latest message.
-	if len(mt.GetHighlights()) == 0 {
-		mt.selectedMessage = 0
-	} else {
-		if mt.selectedMessage > 0 {
-			mt.selectedMessage--
-		} else {
-			return
-		}
-	}
+	// If no message is currently selected, do nothing
+	if mt.selectedMessage == -1 { return }
 
-	mt.Highlight(ms[mt.selectedMessage].ID.String())
-	mt.ScrollToHighlight()
+	// Otherwise select the next message. This causes the desired
+	// behaviour of unselecting messages after the last one.
+	mt.selectedMessage--
+
+	// If a message is selected, highlight it and scroll to it, otherwise remove the highlight
+	if mt.selectedMessage >= 0 {
+		mt.Highlight(ms[mt.selectedMessage].ID.String())
+	        mt.ScrollToHighlight()
+	} else {
+		mt.Highlight()
+	}
 }
 
 func (mt *MessagesText) selectFirstAction() {


### PR DESCRIPTION
Hi! I rewrote a bit of the 'next message' logic to what I think is a reasonable user expectation.

**Currently:** when the last message is selected, pressing 'next message' leaves the last message selected. This has the disadvantage of locking the user in reply mode (writing a message while something is highlighted triggers a reply, regardless of using the 'reply' shortcut) unless they actively close that channel and open it again.

**New:** selecting 'next message' after the last message will reset the selected message to none (-1) and remove highlights. 

I also considered switching the focus to the Message Input, but am not sure if is something wanted. Perhaps it could be added as a config option (something like a top level `jump_to_message_input_after_last_message: false/true`).

This also changes the behavior of 'next message (arrow down)' when nothing is selected. Previously it would select the last message. This is already done by 'previous message (arrow up)' and in my opinion makes more sense given the arrow directions. I disabled it, so pressing 'next message' when nothing is selected does nothing.

Cheers!