### PR TITLE
Draft: Add datetime of original message to title when replying

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -193,9 +193,9 @@ func (mt *MessagesText) replyAction(mention bool) {
 	sy, sm, sd := ms[mt.selectedMessage].Timestamp.Time().Date()
 	ny, nm, nd := time.Now().Date()
 	if sy == ny && sm == nm && sd == nd {
-		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format("15:04:05")
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format(cfg.TimestampsFormatTime)
 	} else {
-		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format("2006-01-02 15:04:05")
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format(cfg.TimestampsFormatDatetime)
 	}
 
 	title += fmt.Sprintf(" @ %s", timestamp)

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -193,9 +193,9 @@ func (mt *MessagesText) replyAction(mention bool) {
 	sy, sm, sd := ms[mt.selectedMessage].Timestamp.Time().Date()
 	ny, nm, nd := time.Now().Date()
 	if sy == ny && sm == nm && sd == nd {
-		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format(cfg.TimestampsFormatTime)
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().In(time.Local).Format(cfg.TimestampsFormatTime)
 	} else {
-		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format(cfg.TimestampsFormatDatetime)
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().In(time.Local).Format(cfg.TimestampsFormatDatetime)
 	}
 
 	title += fmt.Sprintf(" @ %s", timestamp)

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -185,7 +185,20 @@ func (mt *MessagesText) replyAction(mention bool) {
 		return
 	}
 
+	// Add username to reply title
 	title += ms[mt.selectedMessage].Author.Tag()
+
+	// Add timestamp to reply title
+	var timestamp string
+	sy, sm, sd := ms[mt.selectedMessage].Timestamp.Time().Date()
+	ny, nm, nd := time.Now().Date()
+	if sy == ny && sm == nm && sd == nd {
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format("15:04:05")
+	} else {
+		timestamp = ms[mt.selectedMessage].Timestamp.Time().Format("2006-01-02 15:04:05")
+	}
+
+	title += fmt.Sprintf(" @ %s", timestamp)
 	mainFlex.messageInput.SetTitle(title)
 	mainFlex.messageInput.replyMessageIdx = mt.selectedMessage
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	Timestamps             bool `yaml:"timestamps"`
 	TimestampsBeforeAuthor bool `yaml:"timestamps_before_author"`
 
+	TimestampsFormatTime     string `yaml:"timestamps_format_time"`
+	TimestampsFormatDatetime string `yaml:"timestamps_format_datetime"`
+
 	MessagesLimit uint8 `yaml:"messages_limit"`
 
 	Editor string `yaml:"editor"`

--- a/internal/config/config.yml
+++ b/internal/config/config.yml
@@ -6,6 +6,12 @@ timestamps: false
 # Whether to draw the timestamps before the name of author of the message or not. 
 timestamps_before_author: false
 
+# How to display the timestamp on the title of a reply message
+# Note: Go uses the following datetime as its format: Jan 2 15:04:05 2006 MST
+# See https://pkg.go.dev/time#example-Time.Format for more information
+timestamps_format_time: "15:04:05"
+timestamps_format_datetime: "15:04:05 2006-01-02"
+
 # The number of messages to fetch when a text-based channel is selected. The value must be >0 and <=100.
 messages_limit: 50
 


### PR DESCRIPTION
Hi!

It's not always obvious which message is actually being replied to, since the title is only set to the username that sent the original message. With this PR, a timestamp (time for same day, otherwise datetime) is added afterwards, turning this:

```
╔Replying to cyberme0w════════════════════════════╗
║[message input here]                             ║
╚═════════════════════════════════════════════════╝
```

into this (original message from same day as reply):

```
╔Replying to cyberme0w @ 15:45:32═════════════════╗
║[message input here]                             ║
╚═════════════════════════════════════════════════╝
```

and this (original message from previous day or older):

```
╔Replying to cyberme0w @ 2024-01-01 15:45:32══════╗
║[message input here]                             ║
╚═════════════════════════════════════════════════╝
```

If this sounds interesting, I can also add support for the following:
- config entry to enable/disable timestamps in reply title
- configurable timestamp format string, or perhaps a selection of typical datetime formats 

**Note:** there is currently a bug with replies - when replying to a message, if the highlight is moved, the message being replied to will be the highlight *instead of the message that was highlighted when pressing the reply shortcut*. I have a fix for that which I'll add in a separate PR. This means that, while that bug exists, the timestamp added in this PR might not match the message being replied to.

Cheers!