### PR TITLE
Bind original message when typing a reply

### DIFF
--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -64,6 +64,7 @@ func (mi *MessageInput) onInputCapture(event *tcell.EventKey) *tcell.EventKey {
 		mainFlex.messageInput.launchEditorAction()
 		return nil
 	case cfg.Keys.Cancel:
+		mi.replyMessageID = -1
 		mi.reset()
 		return nil
 	}

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -17,11 +17,13 @@ import (
 
 type MessageInput struct {
 	*tview.TextArea
+	replyMessageID int
 }
 
 func newMessageInput() *MessageInput {
 	mi := &MessageInput{
 		TextArea: tview.NewTextArea(),
+		replyMessageID: -1,
 	}
 
 	mi.SetTextStyle(tcell.StyleDefault.Background(tcell.GetColor(cfg.Theme.BackgroundColor)))
@@ -79,7 +81,7 @@ func (mi *MessageInput) sendAction() {
 		return
 	}
 
-	if mainFlex.messagesText.selectedMessage != -1 {
+	if mi.replyMessageID != -1 {
 		ms, err := discordState.Cabinet.Messages(mainFlex.guildsTree.selectedChannelID)
 		if err != nil {
 			log.Println(err)
@@ -88,7 +90,7 @@ func (mi *MessageInput) sendAction() {
 
 		data := api.SendMessageData{
 			Content:         text,
-			Reference:       &discord.MessageReference{MessageID: ms[mainFlex.messagesText.selectedMessage].ID},
+			Reference:       &discord.MessageReference{MessageID: ms[mi.replyMessageID].ID},
 			AllowedMentions: &api.AllowedMentions{RepliedUser: option.False},
 		}
 
@@ -101,7 +103,7 @@ func (mi *MessageInput) sendAction() {
 		go discordState.SendMessage(mainFlex.guildsTree.selectedChannelID, text)
 	}
 
-	mainFlex.messagesText.selectedMessage = -1
+	mi.replyMessageID = -1
 	mainFlex.messagesText.Highlight()
 	mi.reset()
 }

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -17,13 +17,13 @@ import (
 
 type MessageInput struct {
 	*tview.TextArea
-	replyMessageID int
+	replyMessageIdx int
 }
 
 func newMessageInput() *MessageInput {
 	mi := &MessageInput{
 		TextArea: tview.NewTextArea(),
-		replyMessageID: -1,
+		replyMessageIdx: -1,
 	}
 
 	mi.SetTextStyle(tcell.StyleDefault.Background(tcell.GetColor(cfg.Theme.BackgroundColor)))
@@ -64,7 +64,7 @@ func (mi *MessageInput) onInputCapture(event *tcell.EventKey) *tcell.EventKey {
 		mainFlex.messageInput.launchEditorAction()
 		return nil
 	case cfg.Keys.Cancel:
-		mi.replyMessageID = -1
+		mi.replyMessageIdx = -1
 		mi.reset()
 		return nil
 	}
@@ -82,7 +82,7 @@ func (mi *MessageInput) sendAction() {
 		return
 	}
 
-	if mi.replyMessageID != -1 {
+	if mi.replyMessageIdx != -1 {
 		ms, err := discordState.Cabinet.Messages(mainFlex.guildsTree.selectedChannelID)
 		if err != nil {
 			log.Println(err)
@@ -91,7 +91,7 @@ func (mi *MessageInput) sendAction() {
 
 		data := api.SendMessageData{
 			Content:         text,
-			Reference:       &discord.MessageReference{MessageID: ms[mi.replyMessageID].ID},
+			Reference:       &discord.MessageReference{MessageID: ms[mi.replyMessageIdx].ID},
 			AllowedMentions: &api.AllowedMentions{RepliedUser: option.False},
 		}
 
@@ -104,7 +104,7 @@ func (mi *MessageInput) sendAction() {
 		go discordState.SendMessage(mainFlex.guildsTree.selectedChannelID, text)
 	}
 
-	mi.replyMessageID = -1
+	mi.replyMessageIdx = -1
 	mainFlex.messagesText.Highlight()
 	mi.reset()
 }

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -185,7 +185,7 @@ func (mt *MessagesText) replyAction(mention bool) {
 
 	title += ms[mt.selectedMessage].Author.Tag()
 	mainFlex.messageInput.SetTitle(title)
-	mainFlex.messageInput.replyMessageID = mt.selectedMessage
+	mainFlex.messageInput.replyMessageIdx = mt.selectedMessage
 
 	app.SetFocus(mainFlex.messageInput)
 }

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -185,6 +185,7 @@ func (mt *MessagesText) replyAction(mention bool) {
 
 	title += ms[mt.selectedMessage].Author.Tag()
 	mainFlex.messageInput.SetTitle(title)
+	mainFlex.messageInput.replyMessageID = mt.selectedMessage
 
 	app.SetFocus(mainFlex.messageInput)
 }


### PR DESCRIPTION
Hi!

(This PR fixes the reply-bug that I mentioned in #353)

When replying to a message (replying to [username]), if the highlight is moved, the real message being replied to is the highlighted one (e.g. from [username2]) even though the title of the Message Input still says 'replying to [username]'.

This happens because in `sendAction`, the `ms.selectedMessage` is used to get the original message ID, however that changes when the user moves around in the Messages Text (for instance, to check another relevant message). Another issue with this implementation is that every message sent when there is a highlighted message automatically becomes a reply, regardless of if the user pressed the reply shortcut.

I solved this by adding a `replyMessageID` field to the Message Input, which stores the message ID when the user presses the reply shortcut.

### Steps to reproduce wrong title in Message Input:
1. Send two messages with 'a' and 'b'
2. Focus on Messages Text, highlight the 'a' message
3. Press the reply shortcut (default: r)
4. Focus on Messages Text and highlight the 'b' message
5. Write and send a third message

### Expected result:
The last message is a reply to the message 'a'

### Actual result:
The last message is a reply to the message 'b'

### Steps to reproduce reply message without using reply shortcut:
1. Send message with 'a'
2. Focus on Messages Text and highlight 'a'
3. Send a message (note that the Message Input does not have the 'replying to...' title)

### Expected result:
The last message is *not* a reply

### Actual result:
The last message is a reply to message 'a'