### PR TITLE
Parse token flag before accessing keyring

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,13 +10,19 @@ import (
 )
 
 func main() {
-	t, err := keyring.Get(constants.Name, "token")
-	if err != nil {
-		log.Println("token not found in keyring:", err)
-	}
-
-	token := flag.String("token", t, "The authentication token.")
+	// Declare and parse all flags first
+	token := flag.String("token", "", "The authentication token.")
 	flag.Parse()
+
+	// If no token was provided, look it up in the keyring
+	if *token == "" {
+		t, err := keyring.Get(constants.Name, "token")
+		if err != nil {
+			log.Println("Authentication token not found in keyring:", err)
+		} else {
+			*token = t
+		}
+	}
 
 	if err := cmd.Run(*token); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Hi!

I think it makes sense to check if the user provided a token flag *before* accessing the keyring - an actively passed flag+token should be prioritized over the (passive) keyring fallback. Furthermore, there is no need to check the keyring in the first place, given the token is already known.

This also gets rid of the (very minor) annoyance of seeing this error message if discordo is launched with the `--token` flag:

> yyyy/mm/dd hh:mm:ss token not found in keyring: secret not found in keyring

This commit also allows for any future flags to be declared at the top of `main` near each other, keeping things a bit cleaner (in my opinion).

Cheers!