### PR TITLE
Add timezone info to message timestamps

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -94,7 +94,7 @@ func (mt *MessagesText) createMessage(m discord.Message) {
 }
 
 func (mt *MessagesText) createHeader(w io.Writer, m discord.Message, isReply bool) {
-	time := m.Timestamp.Format(time.Kitchen)
+	time := m.Timestamp.Time().In(time.Local).Format(time.Kitchen)
 
 	if cfg.Timestamps && cfg.TimestampsBeforeAuthor {
 		fmt.Fprintf(w, "[::d]%7s[::-] ", time)


### PR DESCRIPTION
Hi! This is a fix for #361 which adds timezone information to message timestamps, allowing them to display the correct time (as opposed to hard-coded UTC).

It is important to note that this does not currently work on Android/Termux due to https://github.com/termux/termux-packages/issues/2622 (or more specifically https://github.com/golang/go/issues/20455).

If you think it's useful, I can also look into adding a config option to hard-code the timezone as a workaround for those users.

Cheers!