### PR TITLE
Fix issues when swapping between Message Input and EDITOR

### DIFF
--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -120,6 +120,7 @@ func (mi *MessageInput) launchEditorAction() {
 		log.Println(err)
 		return
 	}
+	f.WriteString(mi.GetText())
 	f.Close()
 
 	defer os.Remove(f.Name())
@@ -143,5 +144,5 @@ func (mi *MessageInput) launchEditorAction() {
 		return
 	}
 
-	mi.SetText(string(msg), true)
+	mi.SetText(strings.TrimSpace(string(msg)), true)
 }


### PR DESCRIPTION
Hi!

This PR fixes two issues I noticed when swapping between the Message Input and EDITOR:
1. The EDITOR is initialized empty (CreateTemp generates an empty file), even if the user had already typed something.
2. When returning from the EDITOR, a newline is appended for some reason (tested with neovim and nano)

Issue 1 is solved by writing the contents of the Message Input to the temp file.
Issue 2 is solved by trimming leading and trailing whitespace, as Discord already does that after the message is sent.

Cheers!