### PR TITLE
Feat: Add User List

### DIFF
--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -201,6 +201,8 @@ func (gt *GuildsTree) onSelected(n *tview.TreeNode) {
 
 		gt.selectedChannelID = ref
 		app.SetFocus(mainFlex.messageInput)
+
+		mainFlex.userList.updateUsersFromGuildID(c.GuildID)
 	case nil: // Direct messages
 		cs, err := discordState.Cabinet.PrivateChannels()
 		if err != nil {

--- a/cmd/main_flex.go
+++ b/cmd/main_flex.go
@@ -22,20 +22,20 @@ type MainFlex struct {
 	userList     *UserList
 
 	guildsTreeVisible bool
-	userListVisible bool
+	userListVisible   bool
 }
 
 func newMainFlex() *MainFlex {
 	mf := &MainFlex{
 		Flex: tview.NewFlex(),
 
-		mode:         ModeNormal,
-		guildsTree: newGuildsTree(),
+		mode:              ModeNormal,
+		guildsTree:        newGuildsTree(),
 		guildsTreeVisible: true,
-		messagesText: newMessagesText(),
-		messageInput: newMessageInput(),
-		userList: newUserList(),
-		userListVisible: true,
+		messagesText:      newMessagesText(),
+		messageInput:      newMessageInput(),
+		userList:          newUserList(),
+		userListVisible:   true,
 	}
 
 	app.SetBeforeDrawFunc(func(screen tcell.Screen) bool {
@@ -87,18 +87,38 @@ func (mf *MainFlex) onInputCapture(event *tcell.EventKey) *tcell.EventKey {
 		case cfg.Keys.Normal.FocusMessagesText:
 			app.SetFocus(mf.messagesText)
 			return nil
+		case cfg.Keys.Normal.FocusUserList:
+			if mf.userListVisible {
+				app.SetFocus(mf.userList)
+			}
+			return nil
 		case cfg.Keys.Normal.ToggleGuildsTree:
-			// The guilds tree is visible if the numbers of items is two.
-			if mf.GetItemCount() == 2 {
+			// The guilds tree is visible if the state boolean says so
+			if mf.guildsTreeVisible {
 				mf.RemoveItem(mf.guildsTree)
 				if mf.guildsTree.HasFocus() {
 					app.SetFocus(mf)
 				}
+				mf.guildsTreeVisible = false
 			} else {
+				mf.guildsTreeVisible = true
 				mf.init()
 				app.SetFocus(mf.guildsTree)
 			}
-
+			return nil
+		case cfg.Keys.Normal.ToggleUserList:
+			// The user list is visible if the state boolean says so
+			if mf.userListVisible {
+				mf.RemoveItem(mf.userList)
+				if mf.userList.HasFocus() {
+					app.SetFocus(mf)
+				}
+				mf.userListVisible = false
+			} else {
+				mf.userListVisible = true
+				mf.init()
+				app.SetFocus(mf.userList)
+			}
 			return nil
 		}
 

--- a/cmd/main_flex.go
+++ b/cmd/main_flex.go
@@ -19,6 +19,10 @@ type MainFlex struct {
 	guildsTree   *GuildsTree
 	messagesText *MessagesText
 	messageInput *MessageInput
+	userList     *UserList
+
+	guildsTreeVisible bool
+	userListVisible bool
 }
 
 func newMainFlex() *MainFlex {
@@ -26,9 +30,12 @@ func newMainFlex() *MainFlex {
 		Flex: tview.NewFlex(),
 
 		mode:         ModeNormal,
-		guildsTree:   newGuildsTree(),
+		guildsTree: newGuildsTree(),
+		guildsTreeVisible: true,
 		messagesText: newMessagesText(),
 		messageInput: newMessageInput(),
+		userList: newUserList(),
+		userListVisible: true,
 	}
 
 	app.SetBeforeDrawFunc(func(screen tcell.Screen) bool {
@@ -50,13 +57,19 @@ func newMainFlex() *MainFlex {
 func (mf *MainFlex) init() {
 	mf.Clear()
 
-	right := tview.NewFlex()
-	right.SetDirection(tview.FlexRow)
-	right.AddItem(mf.messagesText, 0, 1, false)
-	right.AddItem(mf.messageInput, 3, 1, false)
-	// The guilds tree is always focused first at start-up.
-	mf.AddItem(mf.guildsTree, 0, 1, true)
-	mf.AddItem(right, 0, 4, false)
+	if mf.guildsTreeVisible {
+		mf.AddItem(mf.guildsTree, 0, 1, true)
+	}
+
+	chat := tview.NewFlex()
+	chat.SetDirection(tview.FlexRow)
+	chat.AddItem(mf.messagesText, 0, 1, false)
+	chat.AddItem(mf.messageInput, 3, 1, false)
+	mf.AddItem(chat, 0, 4, false)
+
+	if mf.userListVisible {
+		mf.AddItem(mf.userList, 0, 1, false)
+	}
 }
 
 func (mf *MainFlex) onInputCapture(event *tcell.EventKey) *tcell.EventKey {

--- a/cmd/user_list.go
+++ b/cmd/user_list.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"log"
+	"fmt"
+
+	"github.com/ayn2op/discordo/internal/constants"
+	"github.com/diamondburned/arikawa/v3/discord"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type UserList struct {
+	*tview.TreeView
+
+	root           *tview.TreeNode
+	selectedUserID discord.UserID
+}
+
+func newUserList() *UserList {
+	ul := &UserList{
+		TreeView: tview.NewTreeView(),
+		root: tview.NewTreeNode(""),
+	}
+
+	ul.SetTopLevel(1)
+	ul.SetRoot(ul.root)
+	ul.SetGraphics(true)
+	ul.SetBackgroundColor(tcell.GetColor(cfg.Theme.BackgroundColor))
+	ul.SetSelectedFunc(ul.onSelected)
+
+	ul.SetTitle("Users")
+	ul.SetTitleColor(tcell.GetColor(cfg.Theme.TitleColor))
+	ul.SetTitleAlign(tview.AlignLeft)
+
+	p := cfg.Theme.BorderPadding
+	ul.SetBorder(cfg.Theme.Border)
+	ul.SetBorderColor(tcell.GetColor(cfg.Theme.BorderColor))
+	ul.SetBorderPadding(p[0], p[1], p[2], p[3])
+
+	return ul
+}
+
+func (ul *UserList) createUserNode(user discord.User) {
+	var username string
+	if user.DisplayName != "" {
+		username = user.DisplayName
+	} else {
+		username = user.Username
+	}
+
+	userNode := tview.NewTreeNode(username)
+	userNode.SetReference(user.ID)
+	ul.root.AddChild(userNode)
+	// TODO: Add dropdown commands
+}
+
+func (ul *UserList) updateUsersFromGuildID(g discord.GuildID) {
+	ul.root.ClearChildren()
+	users, err := discordState.Members(g)
+	if err != nil {
+		log.Printf("Unable to find Guild with ID %s\n", g)
+		return
+	}
+	for _, user := range users {
+		ul.createUserNode(user.User)
+	}
+	ul.SetCurrentNode(ul.root)
+}
+
+func (ul *UserList) onSelected(n *tview.TreeNode) {
+	switch ref := n.GetReference().(type) {
+	case discord.UserID:
+		n.ClearChildren()
+		n.AddChild(tview.NewTreeNode(constants.UserListCmdMention))
+		n.SetExpanded(!n.IsExpanded())
+		return
+	case nil: // Dropdown options/commands
+		switch n.GetText() {
+		case constants.UserListCmdMention:
+			mainFlex.messageInput.SetText(fmt.Sprintf("User ID: %d", ref), true)
+		}
+
+		// TODO: run user command based on node name
+		return
+	}
+}

--- a/cmd/user_list.go
+++ b/cmd/user_list.go
@@ -72,13 +72,15 @@ func (ul *UserList) onSelected(n *tview.TreeNode) {
 	switch ref := n.GetReference().(type) {
 	case discord.UserID:
 		n.ClearChildren()
-		n.AddChild(tview.NewTreeNode(constants.UserListCmdMention))
+		n.AddChild(tview.NewTreeNode(constants.UserListCmdMention).SetReference(ref.String()))
 		n.SetExpanded(!n.IsExpanded())
 		return
-	case nil: // Dropdown options/commands
+	case string: // Dropdown options/commands
 		switch n.GetText() {
 		case constants.UserListCmdMention:
-			mainFlex.messageInput.SetText(fmt.Sprintf("User ID: %d", ref), true)
+			mi := mainFlex.messageInput
+			mi.Replace(mi.GetTextLength(), mi.GetTextLength(), fmt.Sprintf("<@%s>", n.GetReference()))
+      app.SetFocus(mi)
 		}
 
 		// TODO: run user command based on node name

--- a/cmd/user_list.go
+++ b/cmd/user_list.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"log"
 	"fmt"
+	"log"
 
 	"github.com/ayn2op/discordo/internal/constants"
 	"github.com/diamondburned/arikawa/v3/discord"
@@ -20,7 +20,7 @@ type UserList struct {
 func newUserList() *UserList {
 	ul := &UserList{
 		TreeView: tview.NewTreeView(),
-		root: tview.NewTreeNode(""),
+		root:     tview.NewTreeNode(""),
 	}
 
 	ul.SetTopLevel(1)
@@ -80,7 +80,7 @@ func (ul *UserList) onSelected(n *tview.TreeNode) {
 		case constants.UserListCmdMention:
 			mi := mainFlex.messageInput
 			mi.Replace(mi.GetTextLength(), mi.GetTextLength(), fmt.Sprintf("<@%s>", n.GetReference()))
-      app.SetFocus(mi)
+			app.SetFocus(mi)
 		}
 
 		// TODO: run user command based on node name

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -10,10 +10,13 @@ type (
 		InsertMode        string `toml:"insert_mode"`
 		FocusGuildsTree   string `toml:"focus_guilds_tree"`
 		FocusMessagesText string `toml:"focus_messages_text"`
+		FocusUserList     string `toml:"focus_user_list"`
 		ToggleGuildsTree  string `toml:"toggle_guild_tree"`
+		ToggleUserList    string `toml:"toggle_user_list"`
 
 		GuildsTree   GuildsTreeNormalModeKeys   `toml:"guilds_tree"`
 		MessagesText MessagesTextNormalModeKeys `toml:"messages_text"`
+		UserList     UserListNormalModeKeys     `toml:"user_list"`
 	}
 
 	GuildsTreeNormalModeKeys struct {
@@ -39,6 +42,14 @@ type (
 		Open   string `toml:"open"`
 	}
 
+	UserListNormalModeKeys struct {
+		SelectCurrent  string `toml:"select_current"`
+		SelectPrevious string `toml:"select_previous"`
+		SelectNext     string `toml:"select_next"`
+		SelectFirst    string `toml:"select_first"`
+		SelectLast     string `toml:"select_last"`
+	}
+
 	InsertModeKeys struct {
 		NormalMode string `toml:"normal_mode"`
 
@@ -58,7 +69,9 @@ func defaultKeys() Keys {
 
 			FocusGuildsTree:   "Ctrl+G",
 			FocusMessagesText: "Ctrl+T",
+			FocusUserList:     "Ctrl+U",
 			ToggleGuildsTree:  "Ctrl+B",
+			ToggleUserList:    "Ctrl+P",
 
 			GuildsTree: GuildsTreeNormalModeKeys{
 				SelectCurrent:  "Enter",
@@ -80,6 +93,13 @@ func defaultKeys() Keys {
 				Delete: "Rune[d]",
 				Yank:   "Rune[y]",
 				Open:   "Rune[o]",
+			},
+			UserList: UserListNormalModeKeys{
+				SelectCurrent:  "Enter",
+				SelectPrevious: "Rune[k]",
+				SelectNext:     "Rune[j]",
+				SelectFirst:    "Rune[g]",
+				SelectLast:     "Rune[G]",
 			},
 		},
 		Insert: InsertModeKeys{

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,3 +5,5 @@ const Name = "discordo"
 const UserAgent = Name + "/0.1 (https://github.com/diamondburned/arikawa, v3)"
 
 const TmpFilePattern = Name + "_*.md"
+
+const UserListCmdMention = "Mention"


### PR DESCRIPTION
Hi!

This PR revolves around adding a new UI element containing a list of members of the current channel, along with a drop-down menu with commands when selecting a user.

The UserList is built similarly to the GuildsTree. Each user is a node with a UserID reference while commands are children (with the UserID referenced as a string, to be able to distinguish between a user and a command).

This opens up the possibility to add more user-related commands in the future. Currently, I have only implemented appending a mention to the current message based on the highlighted user.

I would like to keep this as a draft for now, as I'm still working out some issues here and there, but would like to know what you think / if you have any suggestions.

Preview:
![file](https://github.com/ayn2op/discordo/assets/59916540/cb742e50-545d-4f6b-a1ea-b9167f0c0603)


Cheers!

Closes #129 