### PR TITLE
Add config option to disable auto-expanding folders

### DIFF
--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -53,6 +53,7 @@ func (gt *GuildsTree) createGuildFolderNode(parent *tview.TreeNode, gf gateway.G
 	}
 
 	n := tview.NewTreeNode(name)
+	n.SetExpanded(cfg.Theme.GuildsTree.AutoExpandFolders)
 	parent.AddChild(n)
 
 	for _, gid := range gf.GuildIDs {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,7 @@ type Config struct {
 		BackgroundColor string `yaml:"background_color"`
 
 		GuildsTree struct {
+			AutoExpandFolders bool `yaml:"auto_expand_folders"`
 			Graphics bool `yaml:"graphics"`
 		} `yaml:"guilds_tree"`
 

--- a/internal/config/config.yml
+++ b/internal/config/config.yml
@@ -49,6 +49,7 @@ theme:
   background_color: default
 
   guilds_tree:
+    auto_expand_folders: true
     graphics: true
 
   messages_text:


### PR DESCRIPTION
Hi!

I personally don't use folders, so I hadn't noticed that folders are automatically expanded, but I saw #366 and agree that the user should at least be able to choose (depending on how many folders you have / servers you've joined it might become very cluttered). In any case, I added a config option that allows the user to choose if they want to expand them or not.

Cheers!