### PR TITLE
Add timestamps_format option to configuration file

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -97,10 +97,15 @@ func (mt *MessagesText) createMessage(m discord.Message) {
 }
 
 func (mt *MessagesText) createHeader(w io.Writer, m discord.Message, isReply bool) {
-	time := m.Timestamp.Time().In(time.Local).Format(time.Kitchen)
+    timeFormat := time.Kitchen
+    if cfg.TimestampsISO {
+        timeFormat = time.DateTime
+    }
+
+	time := m.Timestamp.Time().In(time.Local).Format(timeFormat)
 
 	if cfg.Timestamps && cfg.TimestampsBeforeAuthor {
-		fmt.Fprintf(w, "[::d]%7s[::-] ", time)
+		fmt.Fprintf(w, "[::d]%s[::-] ", time)
 	}
 
 	if isReply {

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -97,12 +97,7 @@ func (mt *MessagesText) createMessage(m discord.Message) {
 }
 
 func (mt *MessagesText) createHeader(w io.Writer, m discord.Message, isReply bool) {
-    timeFormat := time.Kitchen
-    if cfg.TimestampsISO {
-        timeFormat = time.DateTime
-    }
-
-	time := m.Timestamp.Time().In(time.Local).Format(timeFormat)
+  	time := m.Timestamp.Time().In(time.Local).Format(cfg.TimestampsFormat)
 
 	if cfg.Timestamps && cfg.TimestampsBeforeAuthor {
 		fmt.Fprintf(w, "[::d]%s[::-] ", time)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 
 	Timestamps             bool `toml:"timestamps"`
 	TimestampsBeforeAuthor bool `toml:"timestamps_before_author"`
-	Timestamps ISO         bool 'toml:"timestamps_iso"`
+	Timestamps ISO         bool `toml:"timestamps_iso"`
 
 	MessagesLimit uint8 `toml:"messages_limit"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 
 	Timestamps             bool `toml:"timestamps"`
 	TimestampsBeforeAuthor bool `toml:"timestamps_before_author"`
-	Timestamps ISO         bool `toml:"timestamps_iso"`
+	TimestampsISO         bool `toml:"timestamps_iso"`
 
 	MessagesLimit uint8 `toml:"messages_limit"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/ayn2op/discordo/internal/constants"
@@ -13,7 +14,7 @@ type Config struct {
 
 	Timestamps             bool `toml:"timestamps"`
 	TimestampsBeforeAuthor bool `toml:"timestamps_before_author"`
-	TimestampsISO          bool `toml:"timestamps_iso"`
+	TimestampsFormat       string `toml:"timestamps_format"`
 
 	MessagesLimit uint8 `toml:"messages_limit"`
 
@@ -29,7 +30,7 @@ func DefaultConfig() Config {
 
 		Timestamps:             false,
 		TimestampsBeforeAuthor: false,
-		TimestampsISO:          false,
+		TimestampsFormat:       time.Kitchen,
 
 		MessagesLimit: 50,
 		Editor:        "default",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 
 	Timestamps             bool `toml:"timestamps"`
 	TimestampsBeforeAuthor bool `toml:"timestamps_before_author"`
+	Timestamps ISO         bool 'toml:"timestamps_iso"`
 
 	MessagesLimit uint8 `toml:"messages_limit"`
 
@@ -28,6 +29,7 @@ func DefaultConfig() Config {
 
 		Timestamps:             false,
 		TimestampsBeforeAuthor: false,
+		TimestampsISO:          false,
 
 		MessagesLimit: 50,
 		Editor:        "default",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 
 	Timestamps             bool `toml:"timestamps"`
 	TimestampsBeforeAuthor bool `toml:"timestamps_before_author"`
-	TimestampsISO         bool `toml:"timestamps_iso"`
+	TimestampsISO          bool `toml:"timestamps_iso"`
 
 	MessagesLimit uint8 `toml:"messages_limit"`
 


### PR DESCRIPTION
Add `TimestampISO` as a boolean value in config defaulted to false.

If `TimestampISO` is true, timestamps will use `time.DateTime` format, otherwise it defaults to original `time.Kitchen`.