### PR TITLE
Guildtree Color

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ title_color = "default"
 background_color = "default"
 
 [theme.guilds_tree]
+tree_color = "white"
 auto_expand_folders = true
 graphics = true
 

--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -53,7 +53,7 @@ func (gt *GuildsTree) createFolderNode(folder gateway.GuildFolder) {
 	}
 
 	root := gt.GetRoot()
-	folderNode := tview.NewTreeNode(name)
+	folderNode := tview.NewTreeNode(name).SetColor(tcell.GetColor(cfg.Theme.GuildsTree.TreeColor))
 	folderNode.SetExpanded(cfg.Theme.GuildsTree.AutoExpandFolders)
 	root.AddChild(folderNode)
 
@@ -70,6 +70,7 @@ func (gt *GuildsTree) createFolderNode(folder gateway.GuildFolder) {
 
 func (gt *GuildsTree) createGuildNode(n *tview.TreeNode, g discord.Guild) {
 	guildNode := tview.NewTreeNode(g.Name)
+	guildNode.SetColor(tcell.GetColor(cfg.Theme.GuildsTree.TreeColor))
 	guildNode.SetReference(g.ID)
 	n.AddChild(guildNode)
 }
@@ -121,7 +122,7 @@ func (gt *GuildsTree) createChannelNode(n *tview.TreeNode, c discord.Channel) *t
 		}
 	}
 
-	channelNode := tview.NewTreeNode(gt.channelToString(c))
+	channelNode := tview.NewTreeNode(gt.channelToString(c)).SetColor(tcell.GetColor(cfg.Theme.GuildsTree.TreeColor))
 	channelNode.SetReference(c.ID)
 	n.AddChild(channelNode)
 	return channelNode

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/diamondburned/arikawa/v3/gateway"
 	"github.com/diamondburned/arikawa/v3/state"
 	"github.com/diamondburned/arikawa/v3/utils/httputil/httpdriver"
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -51,7 +52,7 @@ func (s *State) onRequest(r httpdriver.Request) error {
 
 func (s *State) onReady(r *gateway.ReadyEvent) {
 	root := mainFlex.guildsTree.GetRoot()
-	dmNode := tview.NewTreeNode("Direct Messages")
+	dmNode := tview.NewTreeNode("Direct Messages").SetColor(tcell.GetColor(cfg.Theme.GuildsTree.TreeColor))
 	root.AddChild(dmNode)
 
 	folders := r.UserSettings.GuildFolders

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -16,8 +16,9 @@ type (
 	}
 
 	GuildsTreeTheme struct {
-		AutoExpandFolders bool `toml:"auto_expand_folders"`
-		Graphics          bool `toml:"graphics"`
+		TreeColor         string `toml:"tree_color"`
+		AutoExpandFolders bool   `toml:"auto_expand_folders"`
+		Graphics          bool   `toml:"graphics"`
 	}
 
 	MessagesTextTheme struct {
@@ -36,6 +37,7 @@ func defaultTheme() Theme {
 		TitleColor:      "default",
 
 		GuildsTree: GuildsTreeTheme{
+			TreeColor:         "white",
 			AutoExpandFolders: true,
 			Graphics:          true,
 		},


### PR DESCRIPTION
This commit adds support for configuring ```tree_color``` which sets the background color for the guildtree's cursor, as well as the text color for the guildtree.

A few things to consider:

1. I'm not quite sure if ```tree_color``` is a name that describes what it does properly.
2. This commit has ```tree_color``` set to ```white``` by default, making the text hard to read. This is the same as the current behavior, so might be a good idea to switch it to ```gray``` or something.
3. It is possible to change ```graphics``` color too. Not sure if I should create a separate option for it, or if ```tree_color``` should apply to it.
4. Preferably the background color and the text color should be separate options, but from my understanding, limitations in tview make the two options the same. I've got very limited knowledge in go, so don't take my word for it.

Either way, this should improve legibility.