### PR TITLE
feat: add keybind to logout

### DIFF
--- a/cmd/main_flex.go
+++ b/cmd/main_flex.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"log"
+
+	"github.com/ayn2op/discordo/internal/constants"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"github.com/zalando/go-keyring"
 )
 
 type MainFlex struct {
@@ -49,6 +53,12 @@ func (mf *MainFlex) onInputCapture(event *tcell.EventKey) *tcell.EventKey {
 		return nil
 	case cfg.Keys.FocusMessageInput:
 		app.SetFocus(mf.messageInput)
+		return nil
+	case cfg.Keys.Logout:
+		app.Stop()
+		if err := keyring.Delete(constants.Name, "token"); err != nil {
+			log.Fatal(err)
+		}
 		return nil
 	case cfg.Keys.ToggleGuildsTree:
 		// The guilds tree is visible if the numbers of items is two.

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -15,6 +15,8 @@ type (
 		GuildsTree   GuildsTreeKeys   `toml:"guilds_tree"`
 		MessagesText MessagesTextKeys `toml:"messages_text"`
 		MessageInput MessageInputKeys `toml:"message_input"`
+
+		Logout string `toml:"logout"`
 	}
 
 	GuildsTreeKeys struct {
@@ -44,6 +46,8 @@ func defaultKeys() Keys {
 		FocusMessagesText: "Ctrl+T",
 		FocusMessageInput: "Ctrl+P",
 		ToggleGuildsTree:  "Ctrl+B",
+
+		Logout: "Ctrl+D",
 
 		SelectPrevious: "Rune[k]",
 		SelectNext:     "Rune[j]",


### PR DESCRIPTION
Adds a keybind to log out of the application. Removes the token from keyring if it can be found.

Closes https://github.com/ayn2op/discordo/issues/406