### PR TITLE
feat: color-coded & formatted emotes (#427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ graphics = true
 
 [theme.messages_text]
 author_color = "aqua"
+emote_color = "green"
 reply_indicator = "╭ "
 ```
 

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -146,7 +146,7 @@ func (mt *MessagesText) createBody(w io.Writer, m discord.Message, isReply bool)
 	if isReply {
 		fmt.Fprint(w, "[::d]")
 	}
-	fmt.Fprint(w, markdown.Parse(tview.Escape(body)))
+	fmt.Fprint(w, markdown.Parse(tview.Escape(body), cfg.Theme.MessagesText.EmoteColor))
 	if isReply {
 		fmt.Fprint(w, "[::-]")
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/logger"
+	"github.com/ayn2op/discordo/internal/markdown"
 	"github.com/rivo/tview"
 )
 
@@ -26,6 +27,7 @@ func Run(token string) error {
 	if err != nil {
 		return err
 	}
+	markdown.Init()
 
 	// mainFlex must be initialized before opening a new state.
 	mainFlex = newMainFlex()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/logger"
-	"github.com/ayn2op/discordo/internal/markdown"
 	"github.com/rivo/tview"
 )
 
@@ -27,7 +26,6 @@ func Run(token string) error {
 	if err != nil {
 		return err
 	}
-	markdown.Init()
 
 	// mainFlex must be initialized before opening a new state.
 	mainFlex = newMainFlex()

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -21,8 +21,9 @@ type (
 	}
 
 	MessagesTextTheme struct {
-		AuthorColor    string `toml:"author_color"`
-		ReplyIndicator string `toml:"reply_indicator"`
+		AuthorColor     string `toml:"author_color"`
+		EmoteColor      string `toml:"emote_color"`
+		ReplyIndicator  string `toml:"reply_indicator"`
 	}
 )
 
@@ -40,8 +41,9 @@ func defaultTheme() Theme {
 			Graphics:          true,
 		},
 		MessagesText: MessagesTextTheme{
-			AuthorColor:    "aqua",
-			ReplyIndicator: string(tview.BoxDrawingsLightArcDownAndRight) + " ",
+			AuthorColor:        "aqua",
+			EmoteColor:         "green",
+			ReplyIndicator:     string(tview.BoxDrawingsLightArcDownAndRight) + " ",
 		},
 	}
 }

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -2,6 +2,8 @@ package markdown
 
 import (
 	"regexp"
+
+	"github.com/ayn2op/discordo/internal/config"
 )
 
 var (
@@ -10,7 +12,21 @@ var (
 	underlineRe     = regexp.MustCompile(`(?ms)__(.*?)__`)
 	strikethroughRe = regexp.MustCompile(`(?ms)~~(.*?)~~`)
 	codeblockRe     = regexp.MustCompile("(?ms)`" + `([^` + "`" + `\n]+)` + "`")
+	emoteRe         = regexp.MustCompile(`<(:[a-zA-Z0-9]+:)[0-9]+>`)
+
+	cfg *config.Config
+	emoteColor string
 )
+
+func Init() {
+	var err error
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	
+	emoteColor = cfg.Theme.MessagesText.EmoteColor
+}
 
 func Parse(input string) string {
 	input = boldRe.ReplaceAllString(input, "[::b]$1[::B]")
@@ -18,5 +34,7 @@ func Parse(input string) string {
 	input = underlineRe.ReplaceAllString(input, "[::u]$1[::U]")
 	input = strikethroughRe.ReplaceAllString(input, "[::s]$1[::S]")
 	input = codeblockRe.ReplaceAllString(input, "[::r]$1[::R]")
+	input = emoteRe.ReplaceAllString(input, "[" + emoteColor + "]$1[-:-:-]")
+
 	return input
 }

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -2,8 +2,6 @@ package markdown
 
 import (
 	"regexp"
-
-	"github.com/ayn2op/discordo/internal/config"
 )
 
 var (
@@ -13,22 +11,9 @@ var (
 	strikethroughRe = regexp.MustCompile(`(?ms)~~(.*?)~~`)
 	codeblockRe     = regexp.MustCompile("(?ms)`" + `([^` + "`" + `\n]+)` + "`")
 	emoteRe         = regexp.MustCompile(`<(:[a-zA-Z0-9]+:)[0-9]+>`)
-
-	cfg *config.Config
-	emoteColor string
 )
 
-func Init() {
-	var err error
-	cfg, err := config.Load()
-	if err != nil {
-		return
-	}
-	
-	emoteColor = cfg.Theme.MessagesText.EmoteColor
-}
-
-func Parse(input string) string {
+func Parse(input string, emoteColor string) string {
 	input = boldRe.ReplaceAllString(input, "[::b]$1[::B]")
 	input = italicRe.ReplaceAllString(input, "[::i]$1[::I]")
 	input = underlineRe.ReplaceAllString(input, "[::u]$1[::U]")


### PR DESCRIPTION
Closes #427 

Beyond the regex to format the emote (probably doesn't account for all characters), this pull also adds `emote_color` to theme.messages_text in config. Because of that though, the config has to be loaded in markdown.go and therefore an Init() has been added, called in run.go. Hopefully this is a good way of going about it.