### PR TITLE
Store ID instead of index of message

### DIFF
--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -24,7 +24,6 @@ type MessageInput struct {
 func newMessageInput() *MessageInput {
 	mi := &MessageInput{
 		TextArea:        tview.NewTextArea(),
-		replyMessageID: 0,
 	}
 
 	mi.SetTextStyle(tcell.StyleDefault.Background(tcell.GetColor(cfg.Theme.BackgroundColor)))

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -18,12 +18,13 @@ import (
 type MessageInput struct {
 	*tview.TextArea
 	replyMessageIdx int
+	replyMessageID discord.MessageID 
 }
 
 func newMessageInput() *MessageInput {
 	mi := &MessageInput{
 		TextArea:        tview.NewTextArea(),
-		replyMessageIdx: -1,
+		replyMessageID: 0,
 	}
 
 	mi.SetTextStyle(tcell.StyleDefault.Background(tcell.GetColor(cfg.Theme.BackgroundColor)))
@@ -49,7 +50,7 @@ func newMessageInput() *MessageInput {
 }
 
 func (mi *MessageInput) reset() {
-	mi.replyMessageIdx = -1
+	mi.replyMessageID = 0
 	mi.SetTitle("")
 	mi.SetText("", true)
 }
@@ -80,17 +81,10 @@ func (mi *MessageInput) send() {
 		return
 	}
 
-	logger := slog.With("channel_id", mainFlex.guildsTree.selectedChannelID)
-	if mi.replyMessageIdx != -1 {
-		ms, err := discordState.Cabinet.Messages(mainFlex.guildsTree.selectedChannelID)
-		if err != nil {
-			logger.Error("failed to get messages", "err", err)
-			return
-		}
-
+	if mi.replyMessageID != 0 {
 		data := api.SendMessageData{
 			Content:         text,
-			Reference:       &discord.MessageReference{MessageID: ms[mi.replyMessageIdx].ID},
+			Reference:       &discord.MessageReference{MessageID: mi.replyMessageID},
 			AllowedMentions: &api.AllowedMentions{RepliedUser: option.False},
 		}
 
@@ -111,7 +105,7 @@ func (mi *MessageInput) send() {
 		}()
 	}
 
-	mi.replyMessageIdx = -1
+	mi.replyMessageID = 0
 	mi.reset()
 
 	mainFlex.messagesText.Highlight()

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -17,7 +17,6 @@ import (
 
 type MessageInput struct {
 	*tview.TextArea
-	replyMessageIdx int
 	replyMessageID discord.MessageID 
 }
 

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -22,6 +22,7 @@ type MessagesText struct {
 	*tview.TextView
 
 	selectedMessage int
+	selectedMessageID discord.MessageID
 }
 
 func newMessagesText() *MessagesText {

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -103,7 +103,7 @@ func (mt *MessagesText) createMessage(m discord.Message) {
 
 	switch m.Type {
 	case discord.ChannelPinnedMessage:
-		fmt.Fprint(mt, "[" + cfg.Theme.MessagesText.ContentColor + "]" + m.Author.Username + " pinned a message" + "[-:-:-]")
+		fmt.Fprint(mt, "["+cfg.Theme.MessagesText.ContentColor+"]"+m.Author.Username+" pinned a message"+"[-:-:-]")
 	case discord.DefaultMessage, discord.InlinedReplyMessage:
 		if m.ReferencedMessage != nil {
 			mt.createHeader(mt, *m.ReferencedMessage, true)
@@ -162,22 +162,16 @@ func (mt *MessagesText) createFooter(w io.Writer, m discord.Message) {
 }
 
 func (mt *MessagesText) getSelectedMessage() (*discord.Message, error) {
-	if mt.selectedMessageID == 0 {
+	if !mt.selectedMessageID.IsValid() {
 		return nil, errors.New("no message is currently selected")
 	}
 
-	ms, err := discordState.Cabinet.Messages(mainFlex.guildsTree.selectedChannelID)
+	msg, err := discordState.Cabinet.Message(mainFlex.guildsTree.selectedChannelID, mt.selectedMessageID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not retrieve selected message: %w", err)
 	}
 
-	for idx, m := range ms {
-		for m.ID == mt.selectedMessageID {
-			return &ms[idx], nil
-		}
-	}
-
-	return nil, nil
+	return msg, nil
 }
 
 func (mt *MessagesText) getSelectedMessageIndex() (int, error) {
@@ -257,7 +251,7 @@ func (mt *MessagesText) _select(name string) {
 			}
 		}
 	case cfg.Keys.SelectFirst:
-		mt.selectedMessageID = ms[len(ms) - 1].ID
+		mt.selectedMessageID = ms[len(ms)-1].ID
 	case cfg.Keys.SelectLast:
 		mt.selectedMessageID = ms[0].ID
 	case cfg.Keys.MessagesText.SelectReply:

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -224,14 +224,20 @@ func (mt *MessagesText) _select(name string) {
 		return
 	}
 
+	idx, err := mt.getSelectedMessageIndex()
+	if err != nil {
+		slog.Error("failed to get selected message", "err", err)
+		return
+	}
+
 	switch name {
 	case cfg.Keys.SelectPrevious:
 		// If no message is currently selected, select the latest message.
 		if len(mt.GetHighlights()) == 0 {
-			mt.selectedMessage = 0
+			mt.selectedMessageID = ms[0].ID
 		} else {
-			if mt.selectedMessage < len(ms)-1 {
-				mt.selectedMessage++
+			if idx < len(ms)-1 {
+				mt.selectedMessageID = ms[idx+1].ID
 			} else {
 				return
 			}
@@ -239,10 +245,10 @@ func (mt *MessagesText) _select(name string) {
 	case cfg.Keys.SelectNext:
 		// If no message is currently selected, select the latest message.
 		if len(mt.GetHighlights()) == 0 {
-			mt.selectedMessage = 0
+			mt.selectedMessageID = ms[0].ID
 		} else {
-			if mt.selectedMessage > 0 {
-				mt.selectedMessage--
+			if idx > 0 {
+				mt.selectedMessageID = ms[idx-1].ID
 			} else {
 				return
 			}
@@ -273,7 +279,7 @@ func (mt *MessagesText) _select(name string) {
 		}
 	}
 
-	mt.Highlight(ms[mt.selectedMessage].ID.String())
+	mt.Highlight(mt.selectedMessageID.String())
 	mt.ScrollToHighlight()
 }
 

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -177,6 +177,21 @@ func (mt *MessagesText) getSelectedMessage() (*discord.Message, error) {
 	return &ms[mt.selectedMessage], nil
 }
 
+func (mt *MessagesText) getSelectedMessageIndex() (int, error) {
+	ms, err := discordState.Cabinet.Messages(mainFlex.guildsTree.selectedChannelID)
+	if err != nil {
+		return -1, err
+	}
+
+	for idx, m := range ms {
+		for m.ID == mt.selectedMessageID {
+			return idx, nil
+		}
+	}
+
+	return -1, nil
+}
+
 func (mt *MessagesText) onInputCapture(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Name() {
 	case cfg.Keys.SelectPrevious, cfg.Keys.SelectNext, cfg.Keys.SelectFirst, cfg.Keys.SelectLast, cfg.Keys.MessagesText.SelectReply, cfg.Keys.MessagesText.SelectPin:

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -27,8 +27,6 @@ type MessagesText struct {
 func newMessagesText() *MessagesText {
 	mt := &MessagesText{
 		TextView: tview.NewTextView(),
-
-		selectedMessageID: 0,
 	}
 
 	mt.SetDynamicColors(true)

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -89,7 +89,7 @@ func (s *State) onMessageCreate(m *gateway.MessageCreateEvent) {
 
 func (s *State) onMessageDelete(m *gateway.MessageDeleteEvent) {
 	if mainFlex.guildsTree.selectedChannelID == m.ChannelID {
-		mainFlex.messagesText.selectedMessage = -1
+		mainFlex.messagesText.selectedMessageID = 0
 		mainFlex.messagesText.Highlight()
 		mainFlex.messagesText.Clear()
 


### PR DESCRIPTION
Closes #434 and #407 

`messagesText.selectedMessage` and `messageInput.replyMessageIdx` have been replaced with `messagesText.selectedMessageID` and `messagesInput.replyMessageID`, respectively. Of course, everything else pertaining to the old vars and logic has been changed as well. 

SelectPrev & Next now use a new func, `getSelectedMessageIdx`, to get index of the current message pointed by the ID to move around. 

Since replies now also use ID, there are no more misalignment issues. This closes #407 but also ensure that this kind of bug won't be a thing going forward.

Hopefully the revamp isn't too crazy. :P