### PR TITLE
fix: highlight messages using mouse

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/atotto/clipboard"
@@ -54,6 +55,9 @@ func newMessagesText() *MessagesText {
 		renderer.WithOption("emojiColor", cfg.Theme.MessagesText.EmojiColor),
 		renderer.WithOption("linkColor", cfg.Theme.MessagesText.LinkColor),
 	)
+
+	// register handler for highlight changes
+	mt.SetHighlightedFunc(onHighlighted)
 
 	return mt
 }
@@ -278,6 +282,17 @@ func (mt *MessagesText) _select(name string) {
 
 	mt.Highlight(mt.selectedMessageID.String())
 	mt.ScrollToHighlight()
+}
+
+func onHighlighted(added, removed, remaining []string) {
+	if (len(added) > 0) {
+		mID, err := strconv.ParseInt(added[0], 10, 64)
+		if err != nil {
+			slog.Error("Failed to parse int of region as a message id.","err",err)
+			return
+		}
+		mainFlex.messagesText.selectedMessageID = discord.MessageID(mID)
+	}
 }
 
 func (mt *MessagesText) yank() {

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -56,8 +56,7 @@ func newMessagesText() *MessagesText {
 		renderer.WithOption("linkColor", cfg.Theme.MessagesText.LinkColor),
 	)
 
-	// register handler for highlight changes
-	mt.SetHighlightedFunc(onHighlighted)
+	mt.SetHighlightedFunc(mt.onHighlighted)
 
 	return mt
 }
@@ -284,14 +283,14 @@ func (mt *MessagesText) _select(name string) {
 	mt.ScrollToHighlight()
 }
 
-func onHighlighted(added, removed, remaining []string) {
+func (mt *MessagesText) onHighlighted(added, removed, remaining []string) {
 	if (len(added) > 0) {
 		mID, err := strconv.ParseInt(added[0], 10, 64)
 		if err != nil {
-			slog.Error("Failed to parse int of region as a message id.","err",err)
+			slog.Error("Failed to parse region id as int to use as message id.","err",err)
 			return
 		}
-		mainFlex.messagesText.selectedMessageID = discord.MessageID(mID)
+		mt.selectedMessageID = discord.MessageID(mID)
 	}
 }
 


### PR DESCRIPTION
Hi,

this should synchronize message selections done by mouse with the keyboard way of selecting messages. Thanks to the recent rework of the logic in the keyboard selection, it was quite easy to implement now.

It sets `messagesText.selectedMessageID` after it already was set in `messagesText._select`. So it's done twice for keyboard inputs. I couldn't be bothered to change something about it though as it doesn't affect functionality. Maybe it has some potential for weird race conditions. :shrug: 


Best,