### PR TITLE
feat(config): add theme.border.preset

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/consts"
 	"github.com/ayn2op/discordo/internal/logger"
+	"github.com/rivo/tview"
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 )
@@ -35,6 +36,20 @@ var (
 			if err != nil {
 				return err
 			}
+
+			tview.Borders.Horizontal = cfg.Theme.Border.Type.Horizontal
+			tview.Borders.Vertical = cfg.Theme.Border.Type.Vertical
+			tview.Borders.TopLeft = cfg.Theme.Border.Type.TopLeft
+			tview.Borders.TopRight = cfg.Theme.Border.Type.TopRight
+			tview.Borders.BottomLeft = cfg.Theme.Border.Type.BottomLeft
+			tview.Borders.BottomRight = cfg.Theme.Border.Type.BottomRight
+
+			tview.Borders.HorizontalFocus = tview.Borders.Horizontal
+			tview.Borders.VerticalFocus = tview.Borders.Vertical
+			tview.Borders.TopLeftFocus = tview.Borders.TopLeft
+			tview.Borders.TopRightFocus = tview.Borders.TopRight
+			tview.Borders.BottomLeftFocus = tview.Borders.BottomLeft
+			tview.Borders.BottomRightFocus = tview.Borders.BottomRight
 
 			app = newApp(cfg)
 			return app.run(token)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,12 +37,12 @@ var (
 				return err
 			}
 
-			tview.Borders.Horizontal = cfg.Theme.Border.Type.Horizontal
-			tview.Borders.Vertical = cfg.Theme.Border.Type.Vertical
-			tview.Borders.TopLeft = cfg.Theme.Border.Type.TopLeft
-			tview.Borders.TopRight = cfg.Theme.Border.Type.TopRight
-			tview.Borders.BottomLeft = cfg.Theme.Border.Type.BottomLeft
-			tview.Borders.BottomRight = cfg.Theme.Border.Type.BottomRight
+			tview.Borders.Horizontal = cfg.Theme.Border.Preset.Horizontal
+			tview.Borders.Vertical = cfg.Theme.Border.Preset.Vertical
+			tview.Borders.TopLeft = cfg.Theme.Border.Preset.TopLeft
+			tview.Borders.TopRight = cfg.Theme.Border.Preset.TopRight
+			tview.Borders.BottomLeft = cfg.Theme.Border.Preset.BottomLeft
+			tview.Borders.BottomRight = cfg.Theme.Border.Preset.BottomRight
 
 			tview.Borders.HorizontalFocus = tview.Borders.Horizontal
 			tview.Borders.VerticalFocus = tview.Borders.Vertical

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -1,14 +1,85 @@
 package config
 
-import "github.com/rivo/tview"
+import (
+	"errors"
+
+	"github.com/rivo/tview"
+)
+
+type BorderPreset struct {
+	Horizontal  rune
+	Vertical    rune
+	TopLeft     rune
+	TopRight    rune
+	BottomLeft  rune
+	BottomRight rune
+}
+
+func (p *BorderPreset) UnmarshalTOML(v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return errors.New("invalid type; preset must be a string")
+	}
+
+	switch s {
+	case "double":
+		*p = BorderPreset{
+			Horizontal:  tview.BoxDrawingsDoubleHorizontal,
+			Vertical:    tview.BoxDrawingsDoubleVertical,
+			TopLeft:     tview.BoxDrawingsDoubleDownAndRight,
+			TopRight:    tview.BoxDrawingsDoubleDownAndLeft,
+			BottomLeft:  tview.BoxDrawingsDoubleUpAndRight,
+			BottomRight: tview.BoxDrawingsDoubleUpAndLeft,
+		}
+	case "thick":
+		*p = BorderPreset{
+			Horizontal:  tview.BoxDrawingsHeavyHorizontal,
+			Vertical:    tview.BoxDrawingsHeavyVertical,
+			TopLeft:     tview.BoxDrawingsHeavyDownAndRight,
+			TopRight:    tview.BoxDrawingsHeavyDownAndLeft,
+			BottomLeft:  tview.BoxDrawingsHeavyUpAndRight,
+			BottomRight: tview.BoxDrawingsHeavyUpAndLeft,
+		}
+	case "rounded":
+		*p = BorderPreset{
+			Horizontal:  tview.BoxDrawingsLightHorizontal,
+			Vertical:    tview.BoxDrawingsLightVertical,
+			TopLeft:     tview.BoxDrawingsLightArcDownAndRight,
+			TopRight:    tview.BoxDrawingsLightArcDownAndLeft,
+			BottomLeft:  tview.BoxDrawingsLightArcUpAndRight,
+			BottomRight: tview.BoxDrawingsLightArcUpAndLeft,
+		}
+	case "hidden":
+		*p = BorderPreset{
+			Horizontal:  ' ',
+			Vertical:    ' ',
+			TopLeft:     ' ',
+			TopRight:    ' ',
+			BottomLeft:  ' ',
+			BottomRight: ' ',
+		}
+	default:
+		*p = BorderPreset{
+			Horizontal:  tview.Borders.Horizontal,
+			Vertical:    tview.Borders.Vertical,
+			TopLeft:     tview.Borders.TopLeft,
+			TopRight:    tview.Borders.TopRight,
+			BottomLeft:  tview.Borders.BottomLeft,
+			BottomRight: tview.Borders.BottomRight,
+		}
+	}
+
+	return nil
+}
 
 type (
 	BorderTheme struct {
 		Enabled bool   `toml:"enabled"`
 		Padding [4]int `toml:"padding"`
 
-		Color       string `toml:"color"`
-		ActiveColor string `toml:"active_color"`
+		Color       string       `toml:"color"`
+		ActiveColor string       `toml:"active_color"`
+		Preset      BorderPreset `toml:"preset"`
 	}
 
 	Theme struct {

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"errors"
-
 	"github.com/rivo/tview"
 )
 
@@ -16,12 +14,7 @@ type BorderPreset struct {
 }
 
 func (p *BorderPreset) UnmarshalTOML(v any) error {
-	s, ok := v.(string)
-	if !ok {
-		return errors.New("invalid type; preset must be a string")
-	}
-
-	switch s {
+	switch v.(string) {
 	case "double":
 		*p = BorderPreset{
 			Horizontal:  tview.BoxDrawingsDoubleHorizontal,
@@ -40,7 +33,7 @@ func (p *BorderPreset) UnmarshalTOML(v any) error {
 			BottomLeft:  tview.BoxDrawingsHeavyUpAndRight,
 			BottomRight: tview.BoxDrawingsHeavyUpAndLeft,
 		}
-	case "rounded":
+	case "round":
 		*p = BorderPreset{
 			Horizontal:  tview.BoxDrawingsLightHorizontal,
 			Vertical:    tview.BoxDrawingsLightVertical,
@@ -57,15 +50,6 @@ func (p *BorderPreset) UnmarshalTOML(v any) error {
 			TopRight:    ' ',
 			BottomLeft:  ' ',
 			BottomRight: ' ',
-		}
-	default:
-		*p = BorderPreset{
-			Horizontal:  tview.Borders.Horizontal,
-			Vertical:    tview.Borders.Vertical,
-			TopLeft:     tview.Borders.TopLeft,
-			TopRight:    tview.Borders.TopRight,
-			BottomLeft:  tview.Borders.BottomLeft,
-			BottomRight: tview.Borders.BottomRight,
 		}
 	}
 
@@ -119,6 +103,14 @@ func defaultTheme() Theme {
 
 			Color:       "default",
 			ActiveColor: "gold",
+			Preset: BorderPreset{
+				Horizontal:  tview.Borders.Horizontal,
+				Vertical:    tview.Borders.Vertical,
+				TopLeft:     tview.Borders.TopLeft,
+				TopRight:    tview.Borders.TopRight,
+				BottomLeft:  tview.Borders.BottomLeft,
+				BottomRight: tview.Borders.BottomRight,
+			},
 		},
 
 		BackgroundColor: "default",


### PR DESCRIPTION
default:
<img width="1280" alt="Screenshot 2025-03-29 at 3 10 00 AM" src="https://github.com/user-attachments/assets/d2955ad5-114e-4b88-ba2a-b54da7c1eeb2" />
hidden:
<img width="1280" alt="Screenshot 2025-03-29 at 2 26 07 AM" src="https://github.com/user-attachments/assets/40792969-9de1-4c5a-8a28-41c1b51cd136" />
thick:
<img width="1280" alt="Screenshot 2025-03-29 at 2 46 56 AM" src="https://github.com/user-attachments/assets/06d53bb7-4827-4110-89ae-276cbe13fd8d" />
round:
<img width="1280" alt="Screenshot 2025-03-29 at 2 47 49 AM" src="https://github.com/user-attachments/assets/06265000-bed9-4a3f-bc78-f56fb08c1316" />
double:
<img width="1280" alt="Screenshot 2025-03-29 at 2 48 53 AM" src="https://github.com/user-attachments/assets/5f402bb5-4c2a-4577-b83f-32ed55abeebb" />

