### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: ci
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/ayn2op/discordo/security/code-scanning/1](https://github.com/ayn2op/discordo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required. Based on the workflow's steps:
1. The `actions/checkout@v4` action requires `contents: read` to fetch the repository code.
2. The `actions/upload-artifact@v4` action does not require additional permissions beyond `contents: read`.
3. The `gh api` command in the "Send repository dispatch" step requires `contents: read` and possibly `repository-projects: write` or similar permissions to trigger a repository dispatch event.

We will set `contents: read` globally and add job-specific permissions for the "Send repository dispatch" step if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
