### PR TITLE
feat: render forwarded messages

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -222,7 +222,7 @@ func (mt *MessagesText) authorName(user discord.User, gID discord.GuildID) strin
 func (mt *MessagesText) createForwardedMsg(msg discord.Message) {
 	mt.drawTimestamps(msg.Timestamp)
 	mt.drawAuthor(msg)
-	fmt.Fprintf(mt, "[::d]%s [::-]", mt.cfg.Theme.MessagesText.ForwardIndicator)
+	fmt.Fprintf(mt, "[::d]%s [::-]", mt.cfg.Theme.MessagesText.ForwardedIndicator)
 	mt.drawSnapshotContent(msg.MessageSnapshots[0].Message)
 	fmt.Fprintf(mt, " [::d](%s)[-:-:-] ", mt.formatTimestamp(msg.MessageSnapshots[0].Message.Timestamp))
 }

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -127,7 +127,7 @@ func (mt *MessagesText) createMsg(msg discord.Message) {
 
 	switch msg.Type {
 	case discord.DefaultMessage:
-		if msg.Reference != nil && msg.Reference.Type == 1 { // 1 = forwarded
+		if msg.Reference != nil && msg.Reference.Type == discord.MessageReferenceTypeForward {
 			mt.createForwardedMsg(msg)
 		} else {
 			mt.createDefaultMsg(msg)
@@ -219,7 +219,7 @@ func (mt *MessagesText) authorName(user discord.User, gID discord.GuildID) strin
 func (mt *MessagesText) createForwardedMsg(msg discord.Message) {
 	mt.drawTimestamps(msg.Timestamp)
 	mt.drawAuthor(msg)
-	fmt.Fprintf(mt, "[::d](Forwarded)[-:-:-] ")
+	fmt.Fprintf(mt, "[::d](Forwarded)[::-] ")
 	mt.drawSnapshotContent(msg.MessageSnapshots[0].Message)
 	fmt.Fprintf(mt, " [::d](%s)[-:-:-] ", mt.formatTimestamp(msg.MessageSnapshots[0].Message.Timestamp))
 }

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -221,7 +221,7 @@ func (mt *MessagesText) authorName(user discord.User, gID discord.GuildID) strin
 func (mt *MessagesText) createForwardedMsg(msg discord.Message) {
 	mt.drawTimestamps(msg.Timestamp)
 	mt.drawAuthor(msg)
-	fmt.Fprintf(mt, "[::d](Forwarded)[::-] ")
+	fmt.Fprintf(mt, "[::d]%s [::-]", mt.cfg.Theme.MessagesText.ForwardIndicator)
 	mt.drawSnapshotContent(msg.MessageSnapshots[0].Message)
 	fmt.Fprintf(mt, " [::d](%s)[-:-:-] ", mt.formatTimestamp(msg.MessageSnapshots[0].Message.Timestamp))
 }

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -146,9 +146,12 @@ func (mt *MessagesText) createMsg(msg discord.Message) {
 	fmt.Fprintln(mt)
 }
 
+func (mt *MessagesText) formatTimestamp(ts discord.Timestamp) string {
+	return ts.Time().In(time.Local).Format(mt.cfg.Timestamps.Format)
+}
+
 func (mt *MessagesText) drawTimestamps(ts discord.Timestamp) {
-	time := ts.Time().In(time.Local).Format(mt.cfg.Timestamps.Format)
-	fmt.Fprintf(mt, "[::d]%s[::-] ", time)
+	fmt.Fprintf(mt, "[::d]%s[::-] ", mt.formatTimestamp(ts))
 }
 
 func (mt *MessagesText) drawAuthor(msg discord.Message) {
@@ -218,6 +221,7 @@ func (mt *MessagesText) createForwardedMsg(msg discord.Message) {
 	mt.drawAuthor(msg)
 	fmt.Fprintf(mt, "[::d](Forwarded)[-:-:-] ")
 	mt.drawSnapshotContent(msg.MessageSnapshots[0].Message)
+	fmt.Fprintf(mt, " [::d](%s)[-:-:-] ", mt.formatTimestamp(msg.MessageSnapshots[0].Message.Timestamp))
 }
 
 func (mt *MessagesText) authorColor(user discord.User, gID discord.GuildID) string {

--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -127,7 +127,11 @@ func (mt *MessagesText) createMsg(msg discord.Message) {
 
 	switch msg.Type {
 	case discord.DefaultMessage:
-		mt.createDefaultMsg(msg)
+		if msg.Reference != nil && msg.Reference.Type == 1 { // 1 = forwarded
+			mt.createForwardedMsg(msg)
+		} else {
+			mt.createDefaultMsg(msg)
+		}
 	case discord.InlinedReplyMessage:
 		mt.createReplyMsg(msg)
 
@@ -157,6 +161,12 @@ func (mt *MessagesText) drawContent(msg discord.Message) {
 	c := []byte(tview.Escape(msg.Content))
 	ast := discordmd.ParseWithMessage(c, *discordState.Cabinet, &msg, false)
 	markdown.DefaultRenderer.Render(mt, c, ast)
+}
+
+func (mt *MessagesText) drawSnapshotContent(msg discord.MessageSnapshotMessage) {
+	c := []byte(tview.Escape(msg.Content))
+	// discordmd doesn't support MessageSnapshotMessage, so we just use write it as is. todo?
+	mt.Write(c)
 }
 
 func (mt *MessagesText) createDefaultMsg(msg discord.Message) {
@@ -201,6 +211,13 @@ func (mt *MessagesText) authorName(user discord.User, gID discord.GuildID) strin
 	}
 
 	return name
+}
+
+func (mt *MessagesText) createForwardedMsg(msg discord.Message) {
+	mt.drawTimestamps(msg.Timestamp)
+	mt.drawAuthor(msg)
+	fmt.Fprintf(mt, "[::d](Forwarded)[-:-:-] ")
+	mt.drawSnapshotContent(msg.MessageSnapshots[0].Message)
 }
 
 func (mt *MessagesText) authorColor(user discord.User, gID discord.GuildID) string {

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -59,6 +59,7 @@ type (
 		ShowUsernameColors bool `toml:"show_user_colors"`
 
 		ReplyIndicator string `toml:"reply_indicator"`
+		ForwardIndicator string `toml:"forward_indicator"`
 
 		AuthorColor     string `toml:"author_color"`
 		ContentColor    string `toml:"content_color"`
@@ -99,6 +100,7 @@ func defaultTheme() Theme {
 			ShowUsernameColors: true,
 
 			ReplyIndicator: ">",
+			ForwardIndicator: "<",
 
 			AuthorColor:     "aqua",
 			ContentColor:    tview.Styles.PrimaryTextColor.String(),

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -59,7 +59,7 @@ type (
 		ShowUsernameColors bool `toml:"show_user_colors"`
 
 		ReplyIndicator string `toml:"reply_indicator"`
-		ForwardIndicator string `toml:"forward_indicator"`
+		ForwardedIndicator string `toml:"forwarded_indicator"`
 
 		AuthorColor     string `toml:"author_color"`
 		ContentColor    string `toml:"content_color"`
@@ -100,7 +100,7 @@ func defaultTheme() Theme {
 			ShowUsernameColors: true,
 
 			ReplyIndicator: ">",
-			ForwardIndicator: "<",
+			ForwardedIndicator: "<",
 
 			AuthorColor:     "aqua",
 			ContentColor:    tview.Styles.PrimaryTextColor.String(),


### PR DESCRIPTION
Currently, if you forward a message, the content does not actually show. This PR fixes that 😄 

Before:
![image](https://github.com/user-attachments/assets/99c82f0f-2fbf-4a45-85a8-83be01d82018)

After:
![image](https://github.com/user-attachments/assets/45a310c6-8ad6-4123-8ba8-227639f39cd9)


This currently does *not* render the markdown inside of the message due to a limitation with `discordmd`. If there is another way around this, please let me know and I will add it in.

Thanks!
