### PR TITLE
feat: add ability to disable markdown

### DIFF
--- a/cmd/messages_text.go
+++ b/cmd/messages_text.go
@@ -155,7 +155,11 @@ func (mt *MessagesText) drawAuthor(msg discord.Message) {
 func (mt *MessagesText) drawContent(msg discord.Message) {
 	c := []byte(tview.Escape(msg.Content))
 	ast := discordmd.ParseWithMessage(c, *discordState.Cabinet, &msg, false)
-	markdown.DefaultRenderer.Render(mt, c, ast)
+	if app.cfg.MarkdownEnabled {
+		markdown.DefaultRenderer.Render(mt, c, ast)
+	} else {
+		mt.Write(c) // write the content as is
+	}
 }
 
 func (mt *MessagesText) createDefaultMsg(msg discord.Message) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,8 @@ type (
 		ShowAttachmentLinks bool  `toml:"show_attachment_links"`
 		MessagesLimit       uint8 `toml:"messages_limit"`
 
+		MarkdownEnabled bool `toml:"markdown_enabled"`
+
 		Timestamps    Timestamps    `toml:"timestamps"`
 		Identify      Identify      `toml:"identify"`
 		Notifications Notifications `toml:"notifications"`
@@ -62,6 +64,8 @@ func defaultConfig() *Config {
 		HideBlockedUsers:    true,
 		ShowAttachmentLinks: true,
 		MessagesLimit:       50,
+
+		MarkdownEnabled: true,
 
 		Timestamps: Timestamps{
 			Enabled: true,


### PR DESCRIPTION
Added the ability to disable markdown rendering in the config

Before: _we_
![image](https://github.com/user-attachments/assets/eca6d3b0-5b90-44f5-b55c-3717d05d89ed)

After: `*we*`
![image](https://github.com/user-attachments/assets/be9a11ab-593a-4c7e-868b-f7ce7d991bf9)
