### PR TITLE
feat(config): add new flag to specify config path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,8 @@ func Run() error {
 		}
 	}
 
-	cfg, err := config.Load()
+	configPath := flag.String("config", config.DefaultPath(), "path to the configuration file")
+	cfg, err := config.Load(*configPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,11 @@ var (
 
 func Run() error {
 	logLevel := flag.String("log-level", "info", "log level")
+	logFormat := flag.String("log-format", "text", "log format")
+	token := flag.String("token", "", "authentication token")
+	configPath := flag.String("config", config.DefaultPath(), "path to the configuration file")
+	flag.Parse()
+
 	var level slog.Level
 	switch *logLevel {
 	case "debug":
@@ -33,7 +38,6 @@ func Run() error {
 		level = slog.LevelError
 	}
 
-	logFormat := flag.String("log-format", "text", "log format")
 	var format logger.Format
 	switch *logFormat {
 	case "text":
@@ -46,7 +50,6 @@ func Run() error {
 		return err
 	}
 
-	token := flag.String("token", "", "authentication token")
 	tok := *token
 	if tok == "" {
 		var err error
@@ -56,7 +59,6 @@ func Run() error {
 		}
 	}
 
-	configPath := flag.String("config", config.DefaultPath(), "path to the configuration file")
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,15 +93,18 @@ func defaultConfig() *Config {
 	}
 }
 
-// Reads the configuration file and parses it.
-func Load() (*Config, error) {
+func DefaultPath() string {
 	path, err := os.UserConfigDir()
 	if err != nil {
 		slog.Info("user configuration directory path cannot be determined; falling back to the current directory path")
 		path = "."
 	}
 
-	path = filepath.Join(path, consts.Name, fileName)
+	return filepath.Join(path, consts.Name, fileName)
+}
+
+// Reads the configuration file and parses it.
+func Load(path string) (*Config, error) {
 	f, err := os.Open(path)
 
 	cfg := defaultConfig()


### PR DESCRIPTION
Add a new CLI flag (config) to allow users to specify custom path for
the configuration file.

Closes https://github.com/ayn2op/discordo/issues/546
