### PR TITLE
feat(config): add light border preset

### DIFF
--- a/internal/config/border.go
+++ b/internal/config/border.go
@@ -19,6 +19,8 @@ func (p *BorderPreset) UnmarshalTOML(v any) error {
 		*p = borderPresetThick()
 	case "round":
 		*p = borderPresetRound()
+	case "light":
+		*p = borderPresetLight()
 	case "hidden":
 		*p = BorderPreset{
 			Horizontal:  ' ',
@@ -63,5 +65,16 @@ func borderPresetRound() BorderPreset {
 		TopRight:    tview.BoxDrawingsLightArcDownAndLeft,
 		BottomLeft:  tview.BoxDrawingsLightArcUpAndRight,
 		BottomRight: tview.BoxDrawingsLightArcUpAndLeft,
+	}
+}
+
+func borderPresetLight() BorderPreset {
+	return BorderPreset{
+		Horizontal:  tview.BoxDrawingsLightHorizontal,
+		Vertical:    tview.BoxDrawingsLightVertical,
+		TopLeft:     tview.BoxDrawingsLightDownAndRight,
+		TopRight:    tview.BoxDrawingsLightDownAndLeft,
+		BottomLeft:  tview.BoxDrawingsLightUpAndRight,
+		BottomRight: tview.BoxDrawingsLightUpAndLeft,
 	}
 }


### PR DESCRIPTION
The Arc version of these characters did not exists in the IBM-437 encoding,
which is used by the default Linux tty font.
