### PR TITLE
Fixing a panic caused by notifications

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -46,7 +46,12 @@ func HandleIncomingMessage(state *ningen.State, msg *gateway.MessageCreateEvent,
 
 	notifTitle := msg.Author.DisplayOrTag()
 	if guild != nil {
-		member, _ := state.Member(channel.GuildID, msg.Author.ID)
+		member, err := state.Member(channel.GuildID, msg.Author.ID)
+
+		if err != nil {
+			return err
+		}
+
 		if member.Nick != "" {
 			notifTitle = member.Nick
 		}


### PR DESCRIPTION
periodically i would get a panic like the one below 
`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x7eda6d]

goroutine 27149 [running]:
github.com/ayn2op/discordo/internal/notifications.HandleIncomingMessage(0xc000094000, 0xc000f9d448, 0xc00012d108)
        /home/dsp/dev/misc/discordo-unread/discordo/internal/notifications/notifications.go:50 +0x40d
github.com/ayn2op/discordo/cmd.onMessageCreate(0xc000f9d448)
        /home/dsp/dev/misc/discordo-unread/discordo/cmd/state.go:132 +0x233
reflect.Value.call({0x8b5640?, 0x9bc170?, 0x59c172?}, {0x98908c, 0x4}, {0xc00008eed8, 0x1, 0xc00008ee90?})
        /home/dsp/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.openbsd-amd64/src/reflect/value.go:584 +0xca6
reflect.Value.Call({0x8b5640?, 0x9bc170?, 0xc00008eed8?}, {0xc00008eed8?, 0xc000224b00?, 0x0?})
        /home/dsp/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.4.openbsd-amd64/src/reflect/value.go:368 +0xb9
github.com/diamondburned/arikawa/v3/utils/handler.handler.call({{0xa52030, 0x8ec080}, {0x8b5640, 0x9bc170, 0x13}, {0x0, 0x0, 0x0}, 0x0, 0x0, ...}, ...)
        /home/dsp/go/pkg/mod/github.com/diamondburned/arikawa/v3@v3.5.1-0.20250702014048-91c175a8e0e4/utils/handler/handler.go:341 +0x125
created by github.com/diamondburned/arikawa/v3/utils/handler.handler.Call in goroutine 52
        /home/dsp/go/pkg/mod/github.com/diamondburned/arikawa/v3@v3.5.1-0.20250702014048-91c175a8e0e4/utils/handler/handler.go:330 +0x1a5
`
It seems that diamondburn/ningen can return an error to the state.Member call. this was not checked in discordo. This PR checks it, logs the error and returns it from the HandleIncomingMessage function.