### PR TITLE
feat: app: Enable proper pasting support

### DIFF
--- a/cmd/application.go
+++ b/cmd/application.go
@@ -44,7 +44,8 @@ func newApplication(cfg *config.Config) *application {
 	app.pages.SetInputCapture(app.onPagesInputCapture)
 	app.
 		EnableMouse(cfg.Mouse).
-		SetInputCapture(app.onInputCapture)
+		SetInputCapture(app.onInputCapture).
+		EnablePaste(true)
 	return app
 }
 


### PR DESCRIPTION
Just app.EnablePaste(true) because without it pasting a `<newline>` will
actually send the current message.

Edit: WHY DOES `<newline>` GET TREATED AS AN UNKNOWN HTML TAG IF I DIDN'T WRAP IT WITH BACK TICKS?? THIS IS MARKDOWN GITHUB! MARK. DOWN!