### PR TITLE
refactor(messages_list): Use the new MultiLineList custom primitive

### DIFF
--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -186,7 +186,7 @@ func (gt *guildsTree) onSelected(node *tview.TreeNode) {
 
 		app.messagesList.reset()
 		app.messagesList.setTitle(*channel)
-		app.messagesList.drawMessages(messages)
+		app.messagesList.appendMessages(messages)
 		app.messagesList.ScrollToEnd()
 
 		hasPerm := channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && !discordState.HasPermissions(channel.ID, discord.PermissionSendMessages)

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -164,18 +164,13 @@ func (mi *messageInput) send() {
 		return
 	}
 
-	text = processText(app.guildsTree.selectedChannelID, []byte(text))
+	text = processMessageText(app.guildsTree.selectedChannelID, []byte(text))
 	if text == "" {
 		return
 	}
 
 	if mi.edit {
-		m, err := app.messagesList.selectedMessage()
-		if err != nil {
-			slog.Error("failed to get selected message", "err", err)
-			return
-		}
-
+		m := app.messagesList.GetHighlightedItem().HoldValue.(discord.Message)
 		data := api.EditMessageData{Content: option.NewNullableString(text)}
 		if _, err := discordState.EditMessageComplex(m.ChannelID, m.ID, data); err != nil {
 			slog.Error("failed to edit message", "err", err)
@@ -198,11 +193,11 @@ func (mi *messageInput) send() {
 	}
 
 	mi.reset()
-	app.messagesList.Highlight()
+	app.messagesList.Highlight(-1)
 	app.messagesList.ScrollToEnd()
 }
 
-func processText(cID discord.ChannelID, src []byte) string {
+func processMessageText(cID discord.ChannelID, src []byte) string {
 	var (
 		ranges     [][2]int
 		canMention = true

--- a/cmd/messages_list.go
+++ b/cmd/messages_list.go
@@ -78,6 +78,7 @@ func (ml *messagesList) appendMessages(messages []discord.Message) {
 	for _, m := range slices.Backward(messages) {
 		ml.appendMessage(m)
 	}
+	ml.DrawItems()
 }
 
 func (ml *messagesList) appendMessage(msg discord.Message) {

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -148,6 +148,7 @@ func onReady(r *gateway.ReadyEvent) {
 func onMessageCreate(message *gateway.MessageCreateEvent) {
 	if app.guildsTree.selectedChannelID == message.ChannelID {
 		app.messagesList.appendMessage(message.Message)
+		app.messagesList.DrawItems()
 		app.Draw()
 	}
 

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -147,7 +147,7 @@ func onReady(r *gateway.ReadyEvent) {
 
 func onMessageCreate(message *gateway.MessageCreateEvent) {
 	if app.guildsTree.selectedChannelID == message.ChannelID {
-		app.messagesList.drawMessage(message.Message)
+		app.messagesList.appendMessage(message.Message)
 		app.Draw()
 	}
 
@@ -171,7 +171,7 @@ func onMessageDelete(message *gateway.MessageDeleteEvent) {
 		}
 
 		app.messagesList.reset()
-		app.messagesList.drawMessages(messages)
+		app.messagesList.appendMessages(messages)
 		app.Draw()
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/dchest/jsmin v1.0.0 // indirect
 	github.com/esiqveland/notify v0.13.3 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
+	github.com/gdamore/tcell v1.4.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gorilla/schema v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,11 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/esiqveland/notify v0.13.3 h1:QCMw6o1n+6rl+oLUfg8P1IIDSFsDEb2WlXvVvIJbI/o=
 github.com/esiqveland/notify v0.13.3/go.mod h1:hesw/IRYTO0x99u1JPweAl4+5mwXJibQVUcP0Iu5ORE=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
+github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
+github.com/gdamore/tcell v1.4.0/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
 github.com/gdamore/tcell/v2 v2.9.0 h1:N6t+eqK7/xwtRPwxzs1PXeRWnm0H9l02CrgJ7DLn1ys=
 github.com/gdamore/tcell/v2 v2.9.0/go.mod h1:8/ZoqM9rxzYphT9tH/9LnunhV9oPBqwS8WHGYm5nrmo=
 github.com/gen2brain/beeep v0.11.1 h1:EbSIhrQZFDj1K2fzlMpAYlFOzV8YuNe721A58XcCTYI=
@@ -119,8 +122,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lmittmann/tint v1.1.2 h1:2CQzrL6rslrsyjqLDwD11bZ5OpLBPU+g3G/r5LSfS8w=
 github.com/lmittmann/tint v1.1.2/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/ncruces/zenity v0.10.14 h1:OBFl7qfXcvsdo1NUEGxTlZvAakgWMqz9nG38TuiaGLI=
@@ -256,6 +261,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/ui/multilinelist.go
+++ b/internal/ui/multilinelist.go
@@ -1,0 +1,99 @@
+package ui
+
+import (
+	"strconv"
+	"github.com/ayn2op/tview"
+	"github.com/gdamore/tcell/v2"
+)
+
+type ListItem struct {
+	Text          string
+	HoldValue     any
+	HighlightFunc func(itme *ListItem, highlighted bool)
+}
+
+type MultiLineList struct {
+	*tview.TextView
+	items            []ListItem
+	highlightedIndex int
+}
+
+func NewMultiLineList() *MultiLineList {
+	return &MultiLineList{
+		TextView:         tview.NewTextView().
+		                  SetDynamicColors(true).
+		                  SetRegions(true).
+		                  SetWordWrap(true),
+		highlightedIndex: -1,
+	}
+}
+
+func (mll *MultiLineList) Draw(screen tcell.Screen) {
+	w := mll.TextView.BatchWriter()
+	w.Clear()
+	for idx, item := range mll.items {
+		w.Write([]byte(`["`))
+		w.Write([]byte(strconv.Itoa(idx)))
+		w.Write([]byte(`"]`))
+		w.Write([]byte(item.Text))
+		w.Write([]byte("[\"\"]\n"))
+	}
+	w.Close()
+	if mll.highlightedIndex < 0 {
+		mll.TextView.Highlight("")
+	} else {
+		mll.TextView.Highlight(strconv.Itoa(mll.highlightedIndex))
+	}
+	mll.TextView.Draw(screen)
+}
+
+func (mll *MultiLineList) Highlight(i int) *MultiLineList {
+	oldIdx := mll.highlightedIndex
+	if oldIdx > mll.highlightedIndex {
+		oldIdx = -1
+		mll.highlightedIndex = -1
+	}
+	if i >= len(mll.items) {
+		i = -1
+	}
+	mll.highlightedIndex = i
+	if oldIdx > 0 && mll.items[oldIdx].HighlightFunc != nil {
+		mll.items[oldIdx].HighlightFunc(&mll.items[oldIdx], false)
+	}
+	if i > 0 && mll.items[i].HighlightFunc != nil {
+		mll.items[i].HighlightFunc(&mll.items[i], true)
+	}
+	return mll
+}
+
+func (mll *MultiLineList) GetHighlightedIndex() int {
+	return mll.highlightedIndex
+}
+
+func (mll *MultiLineList) Clear() *MultiLineList {
+	mll.items = nil
+	mll.highlightedIndex = -1
+	mll.TextView.Clear()
+	return mll
+}
+
+func (mll *MultiLineList) AppendItem(text string, holdValue any, highlightFunc func(itme *ListItem, highlighted bool)) *MultiLineList {
+	mll.items = append(mll.items, ListItem {
+		Text: text,
+		HoldValue: holdValue,
+		HighlightFunc: highlightFunc,
+	})
+	return mll
+}
+
+func (mll *MultiLineList) GetItem(i int) ListItem {
+	return mll.items[i]
+}
+
+func (mll *MultiLineList) GetHighlightedItem() ListItem {
+	return mll.items[mll.highlightedIndex]
+}
+
+func (mll *MultiLineList) GetItemCount() int {
+	return len(mll.items)
+}

--- a/internal/ui/multilinelist.go
+++ b/internal/ui/multilinelist.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"strconv"
 	"github.com/ayn2op/tview"
-	"github.com/gdamore/tcell/v2"
 )
 
 type ListItem struct {
@@ -28,23 +27,21 @@ func NewMultiLineList() *MultiLineList {
 	}
 }
 
-func (mll *MultiLineList) Draw(screen tcell.Screen) {
+func (mll *MultiLineList) DrawItems() {
 	w := mll.TextView.BatchWriter()
 	w.Clear()
+	lastIdx := len(mll.items)-1
 	for idx, item := range mll.items {
-		w.Write([]byte(`["`))
+		w.Write([]byte{'[', '"'})
 		w.Write([]byte(strconv.Itoa(idx)))
-		w.Write([]byte(`"]`))
+		w.Write([]byte{'"', ']'})
 		w.Write([]byte(item.Text))
-		w.Write([]byte("[\"\"]\n"))
+		w.Write([]byte{'[', '"', '"', ']'})
+		if idx != lastIdx {
+			w.Write([]byte{'\n'})
+		}
 	}
 	w.Close()
-	if mll.highlightedIndex < 0 {
-		mll.TextView.Highlight("")
-	} else {
-		mll.TextView.Highlight(strconv.Itoa(mll.highlightedIndex))
-	}
-	mll.TextView.Draw(screen)
 }
 
 func (mll *MultiLineList) Highlight(i int) *MultiLineList {
@@ -62,6 +59,12 @@ func (mll *MultiLineList) Highlight(i int) *MultiLineList {
 	}
 	if i > 0 && mll.items[i].HighlightFunc != nil {
 		mll.items[i].HighlightFunc(&mll.items[i], true)
+	}
+	if mll.highlightedIndex < 0 {
+		mll.TextView.Highlight("")
+	} else {
+		mll.TextView.Highlight(strconv.Itoa(mll.highlightedIndex))
+		mll.TextView.ScrollToHighlight()
 	}
 	return mll
 }


### PR DESCRIPTION
The old messages_list draws messages on tview.TextView and then never checks
on them again.

If we used MultiLineList, we can *save* the body of these
messages alongside the message object and have custom highlight functions
for future spoiler support.
