### PR TITLE
feat(clipboard): add wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ go build .
 
 ### Wayland clipboard support
 
-`x11-dev` is required for X11 clipboard compatibility:
-
-- Ubuntu: `apt install xwayland`
-- Arch Linux: `pacman -S xorg-xwayland`
+`wl-clipboard` is required for clipboard support.
 
 ## Usage
 

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/login"
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/gdamore/tcell/v3"
-	"golang.design/x/clipboard"
 )
 
 type application struct {

--- a/cmd/application.go
+++ b/cmd/application.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"log/slog"
 
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/login"
-	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/gdamore/tcell/v3"
 )

--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/ui"
-	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/discord"
 	"github.com/diamondburned/arikawa/v3/gateway"

--- a/cmd/guilds_tree.go
+++ b/cmd/guilds_tree.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/ui"
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/discord"
 	"github.com/diamondburned/arikawa/v3/gateway"
 	"github.com/diamondburned/ningen/v3"
 	"github.com/gdamore/tcell/v3"
-	"golang.design/x/clipboard"
 )
 
 type guildsTree struct {

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/consts"
 	"github.com/ayn2op/discordo/internal/ui"
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/discord"
@@ -29,7 +30,6 @@ import (
 	"github.com/ncruces/zenity"
 	"github.com/sahilm/fuzzy"
 	"github.com/yuin/goldmark/ast"
-	"golang.design/x/clipboard"
 )
 
 const tmpFilePattern = consts.Name + "_*.md"

--- a/cmd/message_input.go
+++ b/cmd/message_input.go
@@ -15,10 +15,10 @@ import (
 	"unicode"
 
 	"github.com/ayn2op/discordo/internal/cache"
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/consts"
 	"github.com/ayn2op/discordo/internal/ui"
-	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/discord"
@@ -395,7 +395,7 @@ func (mi *messageInput) tabSuggestion() {
 }
 
 type memberList []discord.Member
-type userList   []discord.User
+type userList []discord.User
 
 func (ml memberList) String(i int) string {
 	return ml[i].Nick + ml[i].User.DisplayName + ml[i].User.Tag()

--- a/cmd/messages_list.go
+++ b/cmd/messages_list.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ayn2op/discordo/internal/consts"
 	"github.com/ayn2op/discordo/internal/markdown"
 	"github.com/ayn2op/discordo/internal/ui"
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/discord"
@@ -30,7 +31,6 @@ import (
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
-	"golang.design/x/clipboard"
 )
 
 type messagesList struct {

--- a/cmd/messages_list.go
+++ b/cmd/messages_list.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/consts"
 	"github.com/ayn2op/discordo/internal/markdown"
 	"github.com/ayn2op/discordo/internal/ui"
-	"github.com/ayn2op/discordo/internal/clipboard"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/discord"

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -147,7 +147,7 @@ func onReady(r *gateway.ReadyEvent) {
 
 func onMessageCreate(message *gateway.MessageCreateEvent) {
 	if app.chatView.selectedChannel != nil &&
-	   app.chatView.selectedChannel.ID == message.ChannelID {
+		app.chatView.selectedChannel.ID == message.ChannelID {
 		app.chatView.messagesList.drawMessage(app.chatView.messagesList, message.Message)
 		app.Draw()
 	}
@@ -159,14 +159,14 @@ func onMessageCreate(message *gateway.MessageCreateEvent) {
 
 func onMessageUpdate(message *gateway.MessageUpdateEvent) {
 	if app.chatView.selectedChannel != nil &&
-	   app.chatView.selectedChannel.ID == message.ChannelID {
+		app.chatView.selectedChannel.ID == message.ChannelID {
 		onMessageDelete(&gateway.MessageDeleteEvent{ID: message.ID, ChannelID: message.ChannelID, GuildID: message.GuildID})
 	}
 }
 
 func onMessageDelete(message *gateway.MessageDeleteEvent) {
 	if app.chatView.selectedChannel != nil &&
-	   app.chatView.selectedChannel.ID == message.ChannelID {
+		app.chatView.selectedChannel.ID == message.ChannelID {
 		messages, err := discordState.Cabinet.Messages(message.ChannelID)
 		if err != nil {
 			slog.Error("failed to get messages from state", "err", err, "channel_id", message.ChannelID)

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -3,7 +3,8 @@ package clipboard
 import designClipb "golang.design/x/clipboard"
 
 type Format = designClipb.Format
+
 const (
-        FmtText Format = designClipb.FmtText
-        FmtImage       = designClipb.FmtImage
+	FmtText  Format = designClipb.FmtText
+	FmtImage        = designClipb.FmtImage
 )

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,9 @@
+package clipboard
+
+import designClipb "golang.design/x/clipboard"
+
+type Format = designClipb.Format
+const (
+        FmtText Format = designClipb.FmtText
+        FmtImage       = designClipb.FmtImage
+)

--- a/internal/clipboard/clipboard_default.go
+++ b/internal/clipboard/clipboard_default.go
@@ -1,7 +1,7 @@
 //go:build !linux
 package clipboard
 
-import designClipb "golang.desgin/x/clipboard"
+import designClipb "golang.design/x/clipboard"
 
 func Init() error {
 	return designClipb.Init()

--- a/internal/clipboard/clipboard_default.go
+++ b/internal/clipboard/clipboard_default.go
@@ -4,14 +4,8 @@ package clipboard
 
 import designClipb "golang.design/x/clipboard"
 
-func Init() error {
-	return designClipb.Init()
-}
-
-func Read(t Format) []byte {
-	return designClipb.Read(designClipb.Format(t))
-}
-
-func Write(t Format, buf []byte) <-chan struct{} {
-	return designClipb.Write(designClipb.Format(t), buf)
-}
+var (
+	Init = designClipb.Init
+	Read = designClipb.Read
+	Write = designClipb.Write
+)

--- a/internal/clipboard/clipboard_default.go
+++ b/internal/clipboard/clipboard_default.go
@@ -1,4 +1,5 @@
 //go:build !linux
+
 package clipboard
 
 import designClipb "golang.design/x/clipboard"
@@ -14,4 +15,3 @@ func Read(t Format) []byte {
 func Write(t Format, buf []byte) <-chan struct{} {
 	return designClipb.Write(designClipb.Format(t), buf)
 }
-

--- a/internal/clipboard/clipboard_default.go
+++ b/internal/clipboard/clipboard_default.go
@@ -1,0 +1,17 @@
+//go:build !linux
+package clipboard
+
+import designClipb "golang.desgin/x/clipboard"
+
+func Init() error {
+	return designClipb.Init()
+}
+
+func Read(t Format) []byte {
+	return designClipb.Read(designClipb.Format(t))
+}
+
+func Write(t Format, buf []byte) <-chan struct{} {
+	return designClipb.Write(designClipb.Format(t), buf)
+}
+

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -34,14 +34,9 @@ func Read(t Format) []byte {
 	if !wayland {
 		return designClipb.Read(designClipb.Format(t))
 	}
-	var typ string
-	switch t {
-	case FmtText:
-		typ = "text/plain;charset=utf-8"
-	case FmtImage:
-		typ = "image"
-	}
-	cmd := exec.Command("wl-paste", "--no-newline", "--type", typ)
+	// -n: Don't print a newline at the end
+	// -t type: MIME type specifier
+	cmd := exec.Command("wl-paste", "-nt", formatToType(t))
 	outBuffer := bytes.Buffer{}
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
@@ -55,17 +50,22 @@ func Write(t Format, buf []byte) <-chan struct{} {
 	if !wayland {
 		return designClipb.Write(designClipb.Format(t), buf)
 	}
-	var typ string
-	switch t {
-	case FmtText:
-		typ = "text/plain;charset=utf-8"
-	case FmtImage:
-		typ = "image"
-	}
-	cmd := exec.Command("wl-copy", "--type", typ)
+	// -t type: MIME type specifier
+	cmd := exec.Command("wl-copy", "-t", formatToType(t))
 	cmd.Stdin = bytes.NewReader(buf)
 	if err := cmd.Run(); err != nil {
 		slog.Error("failed to write to clipboard", "err", err)
 	}
 	return nil
+}
+
+func formatToType(t Format) string {
+	switch t {
+	case FmtImage:
+		return "image"
+	case FmtText:
+		fallthrough
+	default:
+		return "text/plain;charset=utf-8"
+	}
 }

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -11,11 +11,9 @@ import (
 )
 
 var wayland bool
-var inited bool
 
 func Init() error {
 	if _, ok := os.LookupEnv("WAYLAND_DISPLAY"); !ok {
-		inited = true
 		return designClipb.Init()
 	}
 	if _, err := exec.LookPath("wl-copy"); err != nil {
@@ -25,14 +23,10 @@ func Init() error {
 		return err
 	}
 	wayland = true
-	inited = true
 	return nil
 }
 
 func Read(t Format) []byte {
-	if !inited {
-		return nil
-	}
 	if !wayland {
 		return designClipb.Read(designClipb.Format(t))
 	}
@@ -49,9 +43,6 @@ func Read(t Format) []byte {
 }
 
 func Write(t Format, buf []byte) <-chan struct{} {
-	if !inited {
-		return nil
-	}
 	if !wayland {
 		return designClipb.Write(designClipb.Format(t), buf)
 	}

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -42,7 +42,7 @@ func Read(t Format) []byte {
 	outBuffer := bytes.Buffer{}
 	cmd.Stdout = &outBuffer
 	if err := cmd.Run(); err != nil {
-		slog.Error("failed to write to clipboard", "err", err)
+		slog.Error("failed to read clipboard", "err", err)
 		return nil
 	}
 	return outBuffer.Bytes()

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -20,12 +20,13 @@ func Init() error {
 }
 
 func checkWaylandEnv() bool {
-	if typ := os.Getenv("XDG_SESSION_TYPE"); typ != "wayland" {
-		if _, ok := os.LookupEnv("WAYLAND_DISPLAY"); !ok {
-			return false
-		}
+	if _, ok := os.LookupEnv("WAYLAND_DISPLAY"); !ok {
+		return false
 	}
-	_, err := exec.LookPath("wl-copy")
+	if _, err := exec.LookPath("wl-copy"); err != nil {
+		return false
+	}
+	_, err := exec.LookPath("wl-paste")
 	return err == nil
 }
 

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -1,0 +1,69 @@
+//go:build linux
+package clipboard
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"bytes"
+	designClipb "golang.design/x/clipboard"
+)
+
+var wayland bool
+
+func Init() error {
+	if wayland = checkWaylandEnv(); !wayland {
+		return designClipb.Init()
+	}
+	return nil
+}
+
+func checkWaylandEnv() bool {
+	if typ := os.Getenv("XDG_SESSION_TYPE"); typ != "wayland" {
+		if _, ok := os.LookupEnv("WAYLAND_DISPLAY"); !ok {
+			return false
+		}
+	}
+	_, err := exec.LookPath("wl-copy")
+	return err == nil
+}
+
+func Read(t Format) []byte {
+	if !wayland {
+		return designClipb.Read(designClipb.Format(t))
+	}
+	var typ string
+	switch t {
+	case FmtText:
+		typ = "text/plain;charset=utf-8"
+	case FmtImage:
+		typ = "image"
+	}
+	cmd := exec.Command("wl-paste", "--no-newline", "--type", typ)
+	outBuffer := bytes.Buffer{}
+	cmd.Stdout = &outBuffer
+	if err := cmd.Run(); err != nil {
+		slog.Error("failed to write to clipboard", "err", err)
+		return nil
+	}
+	return outBuffer.Bytes()
+}
+
+func Write(t Format, buf []byte) <-chan struct{} {
+	if !wayland {
+		return designClipb.Write(designClipb.Format(t), buf)
+	}
+	var typ string
+	switch t {
+	case FmtText:
+		typ = "text/plain;charset=utf-8"
+	case FmtImage:
+		typ = "image"
+	}
+	cmd := exec.Command("wl-copy", "--type", typ)
+	cmd.Stdin = bytes.NewReader(buf)
+	if err := cmd.Run(); err != nil {
+		slog.Error("failed to write to clipboard", "err", err)
+	}
+	return nil
+}

--- a/internal/clipboard/clipboard_linux.go
+++ b/internal/clipboard/clipboard_linux.go
@@ -1,12 +1,13 @@
 //go:build linux
+
 package clipboard
 
 import (
+	"bytes"
+	designClipb "golang.design/x/clipboard"
 	"log/slog"
 	"os"
 	"os/exec"
-	"bytes"
-	designClipb "golang.design/x/clipboard"
 )
 
 var wayland bool


### PR DESCRIPTION
Introducing: `internal/clipboard`, a `golang.design/x/clipboard`-compatible
clipboard wrapper with Wayland support using `wl-copy` and `wl-paste`.
