### PR TITLE
fix(config): resolve Ctrl+P conflict between focus_message_input and mentions_list.up

### DIFF
--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -36,7 +36,7 @@ only_on_ping = true
 [keys]
 focus_guilds_tree = "Ctrl+G"
 focus_messages_list = "Ctrl+T"
-focus_message_input = "Ctrl+P"
+focus_message_input = "Ctrl+I"
 # Cycle focus between the widgets.
 focus_previous = "Ctrl+H"
 focus_next = "Ctrl+L"


### PR DESCRIPTION
Changed focus_message_input from Ctrl+P to Ctrl+I to resolve the keybinding conflict where Ctrl+P was intercepted by the global handler before reaching the mentions list. Now Ctrl+P works properly for navigating up in the mentions autocomplete list, and Ctrl+I becomes the new keybinding for focusing the message input field.

Closes #635
