### PR TITLE
feat: display user pronouns in message list

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,111 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/diamondburned/arikawa/v3/discord"
+)
+
+type UserProfile struct {
+	Pronouns string `json:"pronouns"`
+}
+
+type profileResponse struct {
+	UserProfile UserProfile `json:"user_profile"`
+}
+
+type Cache struct {
+	client *http.Client
+	token  string
+
+	mu       sync.RWMutex
+	profiles map[discord.UserID]string
+}
+
+func NewCache(client *http.Client, token string) *Cache {
+	return &Cache{
+		client:   client,
+		token:    token,
+		profiles: make(map[discord.UserID]string),
+	}
+}
+
+func (c *Cache) Get(userID discord.UserID) (string, bool) {
+	c.mu.RLock()
+	pronouns, ok := c.profiles[userID]
+	c.mu.RUnlock()
+	return pronouns, ok
+}
+
+func (c *Cache) Fetch(userID discord.UserID) string {
+	c.mu.RLock()
+	if pronouns, ok := c.profiles[userID]; ok {
+		c.mu.RUnlock()
+		return pronouns
+	}
+	c.mu.RUnlock()
+
+	pronouns := c.fetchFromAPI(userID)
+
+	c.mu.Lock()
+	c.profiles[userID] = pronouns
+	c.mu.Unlock()
+
+	return pronouns
+}
+
+func (c *Cache) fetchFromAPI(userID discord.UserID) string {
+	url := fmt.Sprintf("https://discord.com/api/v9/users/%s/profile?with_mutual_guilds=false&with_mutual_friends=false", userID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ""
+	}
+
+	req.Header.Set("Authorization", c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var profile profileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&profile); err != nil {
+		return ""
+	}
+
+	return profile.UserProfile.Pronouns
+}
+
+func (c *Cache) FetchMany(userIDs []discord.UserID, onComplete func()) {
+	var toFetch []discord.UserID
+
+	c.mu.RLock()
+	for _, id := range userIDs {
+		if _, ok := c.profiles[id]; !ok {
+			toFetch = append(toFetch, id)
+		}
+	}
+	c.mu.RUnlock()
+
+	if len(toFetch) == 0 {
+		return
+	}
+
+	go func() {
+		for _, id := range toFetch {
+			c.Fetch(id)
+		}
+		if onComplete != nil {
+			onComplete()
+		}
+	}()
+}

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -18,7 +18,7 @@ import (
 
 type guildsTree struct {
 	*tview.TreeView
-	cfg  *config.Config
+	cfg      *config.Config
 	chatView *View
 }
 
@@ -217,6 +217,7 @@ func (gt *guildsTree) onSelected(node *tview.TreeNode) {
 		gt.chatView.messagesList.reset()
 		gt.chatView.messagesList.setTitle(*channel)
 		gt.chatView.messagesList.drawMessages(messages)
+		gt.chatView.messagesList.fetchProfiles(messages)
 		gt.chatView.messagesList.ScrollToEnd()
 
 		hasNoPerm := channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && !gt.chatView.state.HasPermissions(channel.ID, discord.PermissionSendMessages)

--- a/internal/ui/chat/message_input.go
+++ b/internal/ui/chat/message_input.go
@@ -39,7 +39,7 @@ var mentionRegex = regexp.MustCompile("@[a-zA-Z0-9._]+")
 
 type messageInput struct {
 	*tview.TextArea
-	cfg  *config.Config
+	cfg      *config.Config
 	chatView *View
 
 	edit            bool
@@ -53,7 +53,7 @@ func newMessageInput(cfg *config.Config, chatView *View) *messageInput {
 	mi := &messageInput{
 		TextArea:        tview.NewTextArea(),
 		cfg:             cfg,
-		chatView: chatView,
+		chatView:        chatView,
 		sendMessageData: &api.SendMessageData{},
 		cache:           cache.NewCache(),
 		mentionsList:    tview.NewList(),

--- a/internal/ui/chat/state.go
+++ b/internal/ui/chat/state.go
@@ -3,8 +3,10 @@ package chat
 import (
 	"context"
 	"log/slog"
+	stdhttp "net/http"
 
 	"github.com/ayn2op/discordo/internal/http"
+	"github.com/ayn2op/discordo/internal/profile"
 	"github.com/diamondburned/arikawa/v3/gateway"
 	"github.com/diamondburned/arikawa/v3/session"
 	"github.com/diamondburned/arikawa/v3/state"
@@ -29,6 +31,9 @@ func (v *View) OpenState(token string) error {
 	session := session.NewCustom(id, http.NewClient(token), handler.New())
 	state := state.NewFromSession(session, defaultstore.New())
 	v.state = ningen.FromState(state)
+
+	httpClient := &stdhttp.Client{Transport: http.NewTransport()}
+	v.profileCache = profile.NewCache(httpClient, token)
 
 	// Handlers
 	v.state.AddHandler(v.onRaw)

--- a/internal/ui/chat/view.go
+++ b/internal/ui/chat/view.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/discordo/internal/keyring"
 	"github.com/ayn2op/discordo/internal/notifications"
+	"github.com/ayn2op/discordo/internal/profile"
 	"github.com/ayn2op/discordo/internal/ui"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/discord"
@@ -36,9 +37,10 @@ type View struct {
 	selectedChannel   *discord.Channel
 	selectedChannelMu sync.RWMutex
 
-	app   *tview.Application
-	cfg   *config.Config
-	state *ningen.State
+	app          *tview.Application
+	cfg          *config.Config
+	state        *ningen.State
+	profileCache *profile.Cache
 
 	onLogout func()
 }
@@ -279,6 +281,7 @@ func (v *View) onReady(r *gateway.ReadyEvent) {
 func (v *View) onMessageCreate(message *gateway.MessageCreateEvent) {
 	if selected := v.SelectedChannel(); selected != nil && selected.ID == message.ChannelID {
 		v.messagesList.drawMessage(v.messagesList, message.Message)
+		v.messagesList.fetchProfiles([]discord.Message{message.Message})
 		v.app.Draw()
 	}
 


### PR DESCRIPTION
Fixes #646

## Changes
- Add profile cache for fetching user pronouns from Discord API
- Display pronouns next to usernames in the message list
- Fetch pronouns asynchronously when channel is selected or new messages arrive