### PR TITLE
fix: show errors on auth fail and save tokens only on success

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -53,18 +53,20 @@ func (a *App) Run(token string) error {
 	screen.EnableFocus()
 	a.inner.SetScreen(screen)
 
-	if token == "" {
-		loginForm := login.NewForm(a.inner, a.cfg, func(token string) {
-			if err := a.showChatView(token); err != nil {
-				slog.Error("failed to show chat view", "err", err)
-			}
-		})
-		a.inner.SetRoot(loginForm)
-	} else {
-		if err := a.showChatView(token); err != nil {
-			return err
+	if token != "" {
+		err = a.showChatView(token)
+		if err == nil {
+			return a.inner.Run()
 		}
+
+		slog.Error("failed to show chat view", "err", err)
 	}
+
+	loginForm := login.NewForm(a.inner, a.cfg, a.showChatView)
+	if token != "" {
+		loginForm.ShowError(fmt.Errorf("authentication failed: %w", err))
+	}
+	a.inner.SetRoot(loginForm)
 
 	return a.inner.Run()
 }


### PR DESCRIPTION
le problema: previously, discordo would try to authenticate via showChatView before calling a.inner.Run(). if the provided token was incorrect, the function would return an error and exit immediately

because a.inner.Run() was never reached, tview never took control of the terminal's lifecycle, so its cleanup logic was never triggered. this left the user's terminal stuck in reporting mode, leaking ansi escape codes (like sgr mouse tracking)

also, while at it, i noticed that invalid tokens were being saved to the keyring regardless of whether the auth returned success, causing the app to repeat the same error on every restart. errors were also not being shown to the user

fix:
1. refactored Run method to ensure that it falls back to login form on auth fail. by ensuring that a.inner.Run() is always reached, we guarantee that it always triggers cleanup
2. refactored login callback to return an error. the login from now only saves the token to the keyring after the app confirms it is valid
3. exposed the error modal via ShowError, allowing the app to display errors to the user

closes issue: #685
