### PR TITLE
feat(config): add message_style and selected_message_style options for messages list

### DIFF
--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -152,6 +152,8 @@ mention_style = { foreground = "blue" }
 emoji_style = { foreground = "green" }
 url_style = { foreground = "blue" }
 attachment_style = { foreground = "yellow" }
+message_style = {}
+selected_message_style = { attributes = "reverse" }
 
 [theme.mentions_list]
 # Note: width and height are capped to the avaliable space

--- a/internal/config/theme.go
+++ b/internal/config/theme.go
@@ -146,6 +146,9 @@ type (
 		EmojiStyle         StyleWrapper `toml:"emoji_style"`
 		URLStyle           StyleWrapper `toml:"url_style"`
 		AttachmentStyle    StyleWrapper `toml:"attachment_style"`
+
+		MessageStyle         StyleWrapper `toml:"message_style"`
+		SelectedMessageStyle StyleWrapper `toml:"selected_message_style"`
 	}
 
 	MentionsListTheme struct {

--- a/internal/ui/chat/messages_list.go
+++ b/internal/ui/chat/messages_list.go
@@ -123,7 +123,9 @@ func (ml *messagesList) buildItem(index int, cursor int) tview.ScrollListItem {
 		SetDynamicColors(true).
 		SetText(ml.renderMessage(message))
 	if index == cursor {
-		tv.SetTextStyle(tcell.StyleDefault.Reverse(true))
+		tv.SetTextStyle(ml.cfg.Theme.MessagesList.SelectedMessageStyle.Style)
+	} else {
+		tv.SetTextStyle(ml.cfg.Theme.MessagesList.MessageStyle.Style)
 	}
 	return tv
 }


### PR DESCRIPTION
Configuration:
```toml
message_style = { foreground = "white" }
selected_message_style = { background = "red" }
```

Preview:
<img width="2176" height="1233" alt="Screenshot 2026-01-17 at 12 48 42 AM" src="https://github.com/user-attachments/assets/6104a3dd-18e5-44b9-89a4-97ecbb5c4fac" />
