### PR TITLE
fix(ui): skip ViewChannel permission check for category channels

### DIFF
--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -200,7 +200,7 @@ func (gt *guildsTree) createGuildNode(n *tview.TreeNode, guild discord.Guild) {
 }
 
 func (gt *guildsTree) createChannelNode(node *tview.TreeNode, channel discord.Channel) {
-	if channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && !gt.chatView.state.HasPermissions(channel.ID, discord.PermissionViewChannel) {
+	if channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && channel.Type != discord.GuildCategory && !gt.chatView.state.HasPermissions(channel.ID, discord.PermissionViewChannel) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Categories are organizational containers whose permissions are inherited by their children. `HasPermissions` returns false for categories when `@everyone` lacks explicit `ViewChannel`, causing the category node to never be created. Child channels then fail to attach to their missing parent node and are silently dropped from the tree.
- Exempts `GuildCategory` from the `ViewChannel` permission check, matching how `DirectMessage` and `GroupDM` are already handled. Empty categories are still naturally hidden by the existing logic in `createChannelNodes`.

Fixes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)