### PR TITLE
fix(ui/chat): mark channel as read after fetching messages

### DIFF
--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -314,14 +314,14 @@ func (gt *guildsTree) onSelected(node *tview.TreeNode) {
 			return
 		}
 
-		go gt.chatView.state.ReadState.MarkRead(channel.ID, channel.LastMessageID)
-
 		limit := gt.cfg.MessagesLimit
 		messages, err := gt.chatView.state.Messages(channel.ID, uint(limit))
 		if err != nil {
 			slog.Error("failed to get messages", "err", err, "channel_id", channel.ID, "limit", limit)
 			return
 		}
+
+		go gt.chatView.state.ReadState.MarkRead(channel.ID, channel.LastMessageID)
 
 		if guildID := channel.GuildID; guildID.IsValid() {
 			gt.chatView.messagesList.requestGuildMembers(guildID, messages)


### PR DESCRIPTION
## Summary
- Fixes #666
- `MarkRead` was called before `Messages()` populated the cabinet, causing ningen's [`markRead`](https://github.com/diamondburned/ningen/blob/98fbd92e134d/states/read/read.go#L204-L208) to early-return when it couldn't find the message in the store
- No ack was sent to Discord and no `UpdateEvent` fired, so the channel's unread/mention styling never cleared
- Fix: move `MarkRead` to after `Messages()` so the message is in the cabinet

## Test plan
- [x] Select an unread channel (white bold) — styling changes to dim (read)
- [x] Verified via debug logging that `channel.LastMessageID` matches the newest fetched message
- [x] Verified via debug logging that the cabinet lookup fails before `Messages()` and succeeds after

🤖 Generated with [Claude Code](https://claude.com/claude-code)