### PR TITLE
feat(ui): display friend nicknames in DM channel list

### DIFF
--- a/internal/ui/chat/channels_picker.go
+++ b/internal/ui/chat/channels_picker.go
@@ -115,7 +115,7 @@ func (cp *channelsPicker) update() {
 
 func (cp *channelsPicker) addChannel(guild *discord.Guild, channel discord.Channel) {
 	var b strings.Builder
-	b.WriteString(ui.ChannelToString(channel, cp.chatView.cfg.Icons))
+	b.WriteString(ui.ChannelToString(channel, cp.chatView.cfg.Icons, cp.chatView.state))
 
 	if guild != nil {
 		b.WriteString(" - ")

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -204,7 +204,7 @@ func (gt *guildsTree) createChannelNode(node *tview.TreeNode, channel discord.Ch
 		return
 	}
 
-	channelNode := tview.NewTreeNode(ui.ChannelToString(channel, gt.cfg.Icons)).SetReference(channel.ID)
+	channelNode := tview.NewTreeNode(ui.ChannelToString(channel, gt.cfg.Icons, gt.chatView.state)).SetReference(channel.ID)
 	if channel.Type == discord.GuildForum {
 		channelNode.SetExpandable(true).SetExpanded(false)
 	}

--- a/internal/ui/chat/messages_list.go
+++ b/internal/ui/chat/messages_list.go
@@ -112,7 +112,7 @@ func (ml *messagesList) reset() {
 }
 
 func (ml *messagesList) setTitle(channel discord.Channel) {
-	title := ui.ChannelToString(channel, ml.cfg.Icons)
+	title := ui.ChannelToString(channel, ml.cfg.Icons, ml.chatView.state)
 	if topic := channel.Topic; topic != "" {
 		title += " - " + topic
 	}

--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ayn2op/discordo/internal/config"
 	"github.com/ayn2op/tview"
 	"github.com/diamondburned/arikawa/v3/discord"
+	"github.com/diamondburned/ningen/v3"
 	"github.com/gdamore/tcell/v3"
 )
 
@@ -61,7 +62,7 @@ func Centered(p tview.Primitive, width, height int) tview.Primitive {
 		AddItem(p, 1, 1, 1, 1, 0, 0, true)
 }
 
-func ChannelToString(channel discord.Channel, icons config.Icons) string {
+func ChannelToString(channel discord.Channel, icons config.Icons, state *ningen.State) string {
 	var icon string
 	switch channel.Type {
 	case discord.DirectMessage, discord.GroupDM:
@@ -71,6 +72,14 @@ func ChannelToString(channel discord.Channel, icons config.Icons) string {
 
 		recipients := make([]string, len(channel.DMRecipients))
 		for i, r := range channel.DMRecipients {
+			if state != nil && channel.Type == discord.DirectMessage {
+				if rel, ok := state.RelationshipState.FullRelationship(r.ID); ok {
+					if rel.Nickname != nil && *rel.Nickname != "" {
+						recipients[i] = *rel.Nickname
+						continue
+					}
+				}
+			}
 			recipients[i] = r.DisplayOrUsername()
 		}
 

--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -73,7 +73,7 @@ func ChannelToString(channel discord.Channel, icons config.Icons, state *ningen.
 		recipients := make([]string, len(channel.DMRecipients))
 		for i, r := range channel.DMRecipients {
 			if state != nil && channel.Type == discord.DirectMessage {
-				if rel, ok := state.RelationshipState.FullRelationship(r.ID); ok {
+				if rel, ok := state.RelationshipState.FullRelationship(r.ID); ok && rel.Type == discord.FriendRelationship {
 					if rel.Nickname != nil && *rel.Nickname != "" {
 						recipients[i] = *rel.Nickname
 						continue


### PR DESCRIPTION
## Summary
- Bump ningen to pick up the new `FullRelationship()` method ([diamondburned/ningen#10](https://github.com/diamondburned/ningen/pull/10))
- Use friend nicknames (when set) in place of display names for 1:1 DMs in the guilds tree, channel picker, and message list title

## Details
Discord's friend nickname feature allows users to set per-friend nicknames visible only to themselves. Previously, ningen's relationship state discarded this field. With the upstream fix merged, we can now display these nicknames in `ChannelToString`.

The `ChannelToString` signature gains a `*ningen.State` parameter to enable the nickname lookup. All three call sites are updated.

## Test plan
- [x] Build: `go build ./...`
- [x] Run discordo, expand Direct Messages — friends with nicknames set show their nickname instead of display name
- [x] Channel picker and message list title also reflect the nickname

<img width="398" height="142" alt="CleanShot 2026-02-26 at 15 17 23" src="https://github.com/user-attachments/assets/c4796c9a-a14b-4959-bbb8-32d8e567add6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)