### PR TITLE
fix(ui/chat): show date separator before first message

### DIFF
--- a/internal/ui/chat/messages_list.go
+++ b/internal/ui/chat/messages_list.go
@@ -238,7 +238,8 @@ func (ml *messagesList) rebuildRows() {
 	rows := make([]messagesListRow, 0, len(ml.messages)*2)
 
 	for i := range ml.messages {
-		if ml.cfg.DateSeparator.Enabled && i > 0 && !sameLocalDate(ml.messages[i-1].Timestamp, ml.messages[i].Timestamp) {
+		// Always show a date separator before the first message, and between messages on different days.
+		if ml.cfg.DateSeparator.Enabled && (i == 0 || !sameLocalDate(ml.messages[i-1].Timestamp, ml.messages[i].Timestamp)) {
 			rows = append(rows, messagesListRow{
 				kind:      messagesListRowSeparator,
 				timestamp: ml.messages[i].Timestamp,


### PR DESCRIPTION
## Summary
- The date separator was only inserted between messages on different days, never before the first message
- This made it impossible to tell the date of a conversation with only one or a few messages on the same day
- Changed the condition to also insert a date separator before the very first message

## Test plan
- [x] Enable `date_separator.enabled = true` in `~/.config/discordo/config.toml`
- [x] Open a DM with only one message — verify a date separator appears above it
- [x] Open a channel with many messages across days — verify date separators still appear correctly between days
- [x] Set `date_separator.enabled = false` — verify no separators appear

Before:
<img width="634" height="100" alt="CleanShot 2026-02-26 at 17 18 28" src="https://github.com/user-attachments/assets/32e1fc09-e48e-418c-9114-ec3a43034d50" />

After:
<img width="554" height="95" alt="CleanShot 2026-02-26 at 17 17 57" src="https://github.com/user-attachments/assets/71b0af44-241a-4e9f-9275-6bb724961e7e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)