### PR TITLE
feat(ui/chat): add user context menu

### DIFF
--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -116,6 +116,7 @@ bottom = "G"
 # Select the currently highlighted text-based channel or expand a guild or channel.
 select_current = "enter"
 yank_id = "i"
+user_context_menu = "ctrl+p"
 collapse_parent_node = "-"
 move_to_parent_node = "p"
 
@@ -143,6 +144,7 @@ delete_confirm = "d"
 # Open the selected message's attachments or hyperlinks in the message
 # using the default browser application.
 open = "o"
+user_context_menu = "ctrl+p"
 # Yank (copy) the selected message's content/url/id.
 yank_content = "y"
 yank_url = "u"

--- a/internal/config/keybinds.go
+++ b/internal/config/keybinds.go
@@ -65,8 +65,9 @@ type PickerKeybinds struct {
 
 type GuildsTreeKeybinds struct {
 	NavigationKeybinds
-	SelectCurrent Keybind `toml:"select_current"`
-	YankID        Keybind `toml:"yank_id"`
+	SelectCurrent   Keybind `toml:"select_current"`
+	YankID          Keybind `toml:"yank_id"`
+	UserContextMenu Keybind `toml:"user_context_menu"`
 
 	CollapseParentNode Keybind `toml:"collapse_parent_node"`
 	MoveToParentNode   Keybind `toml:"move_to_parent_node"`
@@ -80,11 +81,12 @@ type MessagesListKeybinds struct {
 	Reply        Keybind `toml:"reply"`
 	ReplyMention Keybind `toml:"reply_mention"`
 
-	Cancel        Keybind `toml:"cancel"`
-	Edit          Keybind `toml:"edit"`
-	Delete        Keybind `toml:"delete"`
-	DeleteConfirm Keybind `toml:"delete_confirm"`
-	Open          Keybind `toml:"open"`
+	Cancel          Keybind `toml:"cancel"`
+	Edit            Keybind `toml:"edit"`
+	Delete          Keybind `toml:"delete"`
+	DeleteConfirm   Keybind `toml:"delete_confirm"`
+	Open            Keybind `toml:"open"`
+	UserContextMenu Keybind `toml:"user_context_menu"`
 
 	YankContent Keybind `toml:"yank_content"`
 	YankURL     Keybind `toml:"yank_url"`
@@ -106,6 +108,9 @@ type MentionsListKeybinds struct {
 	NavigationKeybinds
 }
 
+type UserContextMenuKeybinds struct {
+}
+
 type Keybinds struct {
 	ToggleGuildsTree     Keybind `toml:"toggle_guilds_tree"`
 	ToggleChannelsPicker Keybind `toml:"toggle_channels_picker"`
@@ -123,7 +128,8 @@ type Keybinds struct {
 	GuildsTree   GuildsTreeKeybinds   `toml:"guilds_tree"`
 	MessagesList MessagesListKeybinds `toml:"messages_list"`
 	MessageInput MessageInputKeybinds `toml:"message_input"`
-	MentionsList MentionsListKeybinds `toml:"mentions_list"`
+	MentionsList    MentionsListKeybinds    `toml:"mentions_list"`
+	UserContextMenu UserContextMenuKeybinds `toml:"user_context_menu"`
 
 	Logout Keybind `toml:"logout"`
 	Quit   Keybind `toml:"quit"`
@@ -165,6 +171,7 @@ func defaultKeybinds() Keybinds {
 			},
 			SelectCurrent:      newKeybind("enter", "sel"),
 			YankID:             newKeybind("i", "copy id"),
+			UserContextMenu:    newKeybind("ctrl+p", "user menu"),
 			CollapseParentNode: newKeybind("-", "collapse"),
 			MoveToParentNode:   newKeybind("p", "parent"),
 		},
@@ -192,9 +199,10 @@ func defaultKeybinds() Keybinds {
 				"delete",
 			),
 			Open:        newKeybind("o", "open"),
-			YankContent: newKeybind("y", "copy text"),
-			YankURL:     newKeybind("u", "copy url"),
-			YankID:      newKeybind("i", "copy id"),
+			UserContextMenu: newKeybind("ctrl+p", "user menu"),
+			YankContent:     newKeybind("y", "copy text"),
+			YankURL:         newKeybind("u", "copy url"),
+			YankID:          newKeybind("i", "copy id"),
 		},
 		MessageInput: MessageInputKeybinds{
 			Paste:          newKeybind("ctrl+v", "paste"),
@@ -205,6 +213,7 @@ func defaultKeybinds() Keybinds {
 			OpenEditor:     newKeybind("ctrl+e", "editor"),
 			OpenFilePicker: newKeybind("ctrl+\\", "attach"),
 		},
+		UserContextMenu: UserContextMenuKeybinds{},
 		MentionsList: MentionsListKeybinds{
 			NavigationKeybinds: NavigationKeybinds{
 				Up:     newKeybind("ctrl+p", "up"),

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -443,7 +443,7 @@ func (gt *guildsTree) InputHandler(event *tcell.EventKey) tview.Command {
 
 	case keybind.Matches(event, gt.cfg.Keybinds.GuildsTree.UserContextMenu.Keybind):
 		if gt.showUserContextMenu() {
-			return consume
+			return consumeRedraw
 		}
 	case keybind.Matches(event, gt.cfg.Keybinds.GuildsTree.YankID.Keybind):
 		gt.yankID()

--- a/internal/ui/chat/keybinds.go
+++ b/internal/ui/chat/keybinds.go
@@ -26,6 +26,10 @@ func (v *View) FullHelp() [][]keybind.Keybind {
 }
 
 func (v *View) activeKeyMap() help.KeyMap {
+	if v.GetVisible(userContextMenuLayerName) {
+		return v.userContextMenu
+	}
+
 	if v.GetVisible(channelsPickerLayerName) {
 		return v.channelsPicker
 	}

--- a/internal/ui/chat/messages_list.go
+++ b/internal/ui/chat/messages_list.go
@@ -55,21 +55,18 @@ func (r *rectTracker) SetRect(x, y, w, h int) {
 
 func (r *rectTracker) GetRect() (int, int, int, int)        { return r.x, r.y, r.w, r.h }
 func (r *rectTracker) Draw(screen tcell.Screen)              { if r.inner != nil { r.inner.Draw(screen) } }
-func (r *rectTracker) InputHandler(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
-	if r.inner != nil { r.inner.InputHandler(event, setFocus) }
+func (r *rectTracker) InputHandler(event *tcell.EventKey) tview.Command {
+	if r.inner != nil { return r.inner.InputHandler(event) }; return nil
 }
 func (r *rectTracker) Focus(delegate func(p tview.Primitive))   { if r.inner != nil { r.inner.Focus(delegate) } }
 func (r *rectTracker) HasFocus() bool                           { if r.inner != nil { return r.inner.HasFocus() }; return false }
 func (r *rectTracker) Blur()                                    { if r.inner != nil { r.inner.Blur() } }
-func (r *rectTracker) MouseHandler(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (bool, tview.Primitive) {
-	if r.inner != nil { return r.inner.MouseHandler(action, event, setFocus) }; return false, nil
+func (r *rectTracker) MouseHandler(action tview.MouseAction, event *tcell.EventMouse) (tview.Primitive, tview.Command) {
+	if r.inner != nil { return r.inner.MouseHandler(action, event) }; return nil, nil
 }
-func (r *rectTracker) PasteHandler(text string, setFocus func(p tview.Primitive)) {
-	if r.inner != nil { r.inner.PasteHandler(text, setFocus) }
+func (r *rectTracker) PasteHandler(text string) tview.Command {
+	if r.inner != nil { return r.inner.PasteHandler(text) }; return nil
 }
-func (r *rectTracker) IsDirty() bool   { if r.inner != nil { return r.inner.IsDirty() }; return false }
-func (r *rectTracker) MarkDirty()      { if r.inner != nil { r.inner.MarkDirty() } }
-func (r *rectTracker) MarkClean()      { if r.inner != nil { r.inner.MarkClean() } }
 func (r *rectTracker) Height(width int) int { if r.inner != nil { return r.inner.Height(width) }; return 0 }
 
 type messagesList struct {
@@ -629,7 +626,7 @@ func (ml *messagesList) InputHandler(event *tcell.EventKey) tview.Command {
 		return consumeRedraw
 	case keybind.Matches(event, ml.cfg.Keybinds.MessagesList.UserContextMenu.Keybind):
 		ml.showUserContextMenu()
-		return consume
+		return consumeRedraw
 	}
 
 	// Do not fall through to List defaults for unmatched keys.

--- a/internal/ui/chat/user_context_menu.go
+++ b/internal/ui/chat/user_context_menu.go
@@ -1,0 +1,426 @@
+package chat
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/ayn2op/discordo/internal/config"
+	"github.com/ayn2op/discordo/internal/ui"
+	"github.com/ayn2op/tview"
+	"github.com/ayn2op/tview/help"
+	"github.com/ayn2op/tview/keybind"
+	"github.com/ayn2op/tview/layers"
+	"github.com/diamondburned/arikawa/v3/discord"
+	"github.com/gdamore/tcell/v3"
+)
+
+const (
+	userContextMenuLayerName = "userContextMenu"
+	noteFormLayerName        = "noteForm"
+	profileLayerName         = "profile"
+)
+
+type userContextMenuItem struct {
+	key    rune
+	label  string
+	action func()
+}
+
+type userContextMenu struct {
+	*tview.List
+	items         []userContextMenuItem
+	chatView      *View
+	cfg           *config.Config
+	previousFocus tview.Primitive
+}
+
+var _ help.KeyMap = (*userContextMenu)(nil)
+
+func newUserContextMenu(cfg *config.Config, chatView *View) *userContextMenu {
+	m := &userContextMenu{
+		List:     tview.NewList(),
+		cfg:      cfg,
+		chatView: chatView,
+	}
+
+	m.Box = ui.ConfigureBox(m.Box, &cfg.Theme)
+	m.SetSnapToItems(true)
+	m.SetBuilder(m.buildItem)
+	return m
+}
+
+func (m *userContextMenu) buildItem(index int, _ int) tview.ListItem {
+	if index < 0 || index >= len(m.items) {
+		return nil
+	}
+
+	item := m.items[index]
+	var baseStyle tcell.Style
+	keyStyle := baseStyle.Foreground(tcell.ColorGreen).Underline(true)
+
+	// Find the hotkey letter within the label and style it inline.
+	keyStr := strings.ToUpper(string(item.key))
+	idx := strings.Index(strings.ToUpper(item.label), keyStr)
+
+	var segments []tview.Segment
+	if idx >= 0 {
+		if idx > 0 {
+			segments = append(segments, tview.NewSegment(item.label[:idx], baseStyle))
+		}
+		segments = append(segments, tview.NewSegment(item.label[idx:idx+len(keyStr)], keyStyle))
+		if idx+len(keyStr) < len(item.label) {
+			segments = append(segments, tview.NewSegment(item.label[idx+len(keyStr):], baseStyle))
+		}
+	} else {
+		segments = append(segments, tview.NewSegment(item.label, baseStyle))
+	}
+
+	line := tview.NewLine(segments...)
+
+	return tview.NewTextView().
+		SetScrollable(false).
+		SetWrap(false).
+		SetWordWrap(false).
+		SetLines([]tview.Line{line})
+}
+
+func (m *userContextMenu) build(user discord.User, guildID discord.GuildID) {
+	m.items = nil
+
+	me, _ := m.chatView.state.Cabinet.Me()
+	isSelf := me.ID == user.ID
+
+	title := user.DisplayOrUsername()
+	m.SetTitle(title)
+
+	// Profile — always shown
+	m.items = append(m.items, userContextMenuItem{
+		key:   'P',
+		label: "Profile",
+		action: func() {
+			m.showProfile(user, guildID)
+		},
+	})
+
+	if !isSelf {
+		rel := m.chatView.state.RelationshipState.Relationship(user.ID)
+
+		// Show "Message" only if we're friends or have an existing DM channel,
+		// since first-time DMs to non-friends typically hit a captcha wall.
+		if rel == discord.FriendRelationship || m.hasExistingDM(user.ID) {
+			m.items = append(m.items, userContextMenuItem{
+				key:   'M',
+				label: "Message",
+				action: func() {
+					go m.openDM(user.ID)
+				},
+			})
+		}
+	}
+
+	// Add Note — always shown
+	m.items = append(m.items, userContextMenuItem{
+		key:   'N',
+		label: "Note",
+		action: func() {
+			m.showNoteForm(user.ID)
+		},
+	})
+
+	m.SetCursor(-1)
+	m.MarkDirty()
+}
+
+// showAt displays the menu anchored near the given screen position. The menu
+// is placed above anchorY when there is room, otherwise below it.
+func (m *userContextMenu) showAt(anchorX, anchorY int) {
+	m.previousFocus = m.chatView.app.GetFocus()
+
+	// Compute menu dimensions.
+	menuWidth := 0
+	for _, item := range m.items {
+		// "[X] Label" = 4 + len(label)
+		w := 4 + len(item.label)
+		if w > menuWidth {
+			menuWidth = w
+		}
+	}
+	// Account for border + padding.
+	menuWidth += 4
+	menuHeight := len(m.items) + 2
+
+	_, _, screenWidth, screenHeight := m.chatView.GetRect()
+
+	x := anchorX
+	if x+menuWidth > screenWidth {
+		x = screenWidth - menuWidth
+	}
+	if x < 0 {
+		x = 0
+	}
+
+	y := anchorY - menuHeight
+	if y < 0 {
+		y = anchorY
+	}
+	if y+menuHeight > screenHeight {
+		y = screenHeight - menuHeight
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	m.SetRect(x, y, menuWidth, menuHeight)
+
+	m.chatView.
+		AddLayer(
+			m,
+			layers.WithName(userContextMenuLayerName),
+			layers.WithVisible(true),
+			layers.WithOverlay(),
+		).
+		SendToFront(userContextMenuLayerName)
+	m.chatView.app.SetFocus(m)
+}
+
+func (m *userContextMenu) hide() {
+	m.chatView.RemoveLayer(userContextMenuLayerName)
+	if m.previousFocus != nil {
+		m.chatView.app.SetFocus(m.previousFocus)
+	}
+}
+
+func (m *userContextMenu) executeByKey(s string) {
+	s = strings.ToUpper(s)
+	for _, item := range m.items {
+		if string(item.key) == s {
+			action := item.action
+			m.hide()
+			action()
+			return
+		}
+	}
+}
+
+func (m *userContextMenu) handleInput(event *tcell.EventKey) *tcell.EventKey {
+	if event.Key() == tcell.KeyEscape {
+		m.hide()
+		return nil
+	}
+
+	if event.Key() == tcell.KeyRune {
+		m.executeByKey(event.Str())
+		return nil
+	}
+
+	return nil
+}
+
+func (m *userContextMenu) InputHandler(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	event = m.handleInput(event)
+	if event == nil {
+		return
+	}
+	m.List.InputHandler(event, setFocus)
+}
+
+func (m *userContextMenu) hasExistingDM(userID discord.UserID) bool {
+	channels, err := m.chatView.state.PrivateChannels()
+	if err != nil {
+		return false
+	}
+	for _, ch := range channels {
+		if ch.Type == discord.DirectMessage {
+			for _, r := range ch.DMRecipients {
+				if r.ID == userID {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// Action implementations
+
+func (m *userContextMenu) openDM(userID discord.UserID) {
+	channel, err := m.chatView.state.CreatePrivateChannel(userID)
+	if err != nil {
+		slog.Error("failed to create private channel", "user_id", userID, "err", err)
+		return
+	}
+
+	m.chatView.app.QueueUpdateDraw(func() {
+		gt := m.chatView.guildsTree
+
+		// Ensure the DM root node is expanded so channel nodes exist.
+		if dmRoot := gt.findNodeByReference(dmNode{}); dmRoot != nil {
+			if len(dmRoot.GetChildren()) == 0 {
+				gt.onSelected(dmRoot)
+			}
+		}
+
+		// If the channel node doesn't exist yet (newly created DM), add it.
+		node := gt.findNodeByReference(channel.ID)
+		if node == nil {
+			if dmRoot := gt.findNodeByReference(dmNode{}); dmRoot != nil {
+				gt.createChannelNode(dmRoot, *channel)
+				node = gt.findNodeByReference(channel.ID)
+			}
+		}
+
+		if node == nil {
+			slog.Error("failed to find DM channel node", "channel_id", channel.ID)
+			return
+		}
+
+		gt.expandPathToNode(node)
+		gt.SetCurrentNode(node)
+		gt.onSelected(node)
+	})
+}
+
+func (m *userContextMenu) showNoteForm(userID discord.UserID) {
+	previousFocus := m.chatView.app.GetFocus()
+	currentNote := m.chatView.state.NoteState.Note(userID)
+
+	form := tview.NewForm()
+	form.AddInputField("Note", currentNote, 40, nil)
+	form.AddButton("Save", func() {
+		noteField, _ := form.GetFormItemByLabel("Note").(*tview.InputField)
+		note := noteField.GetText()
+		go func() {
+			if err := m.chatView.state.SetNote(userID, note); err != nil {
+				slog.Error("failed to set note", "user_id", userID, "err", err)
+			}
+		}()
+		m.chatView.RemoveLayer(noteFormLayerName)
+		m.chatView.app.SetFocus(previousFocus)
+	})
+	form.AddButton("Cancel", func() {
+		m.chatView.RemoveLayer(noteFormLayerName)
+		m.chatView.app.SetFocus(previousFocus)
+	})
+	form.SetCancelFunc(func() {
+		m.chatView.RemoveLayer(noteFormLayerName)
+		m.chatView.app.SetFocus(previousFocus)
+	})
+	form.SetTitle("Set Note")
+	form.SetBorders(tview.BordersAll)
+
+	m.chatView.
+		AddLayer(
+			ui.Centered(form, 50, 7),
+			layers.WithName(noteFormLayerName),
+			layers.WithResize(true),
+			layers.WithVisible(true),
+			layers.WithOverlay(),
+		).
+		SendToFront(noteFormLayerName)
+	m.chatView.app.SetFocus(form)
+}
+
+func (m *userContextMenu) showProfile(user discord.User, guildID discord.GuildID) {
+	previousFocus := m.chatView.app.GetFocus()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Display Name: %s\n", user.DisplayOrUsername())
+	fmt.Fprintf(&b, "Username:     %s\n", user.Username)
+	if user.Discriminator != "0" && user.Discriminator != "" {
+		fmt.Fprintf(&b, "Discriminator: #%s\n", user.Discriminator)
+	}
+	fmt.Fprintf(&b, "ID:           %s\n", user.ID)
+	fmt.Fprintf(&b, "Created:      %s\n", user.CreatedAt().Format("January 2, 2006"))
+	if user.Bot {
+		b.WriteString("Bot:          Yes\n")
+	}
+
+	if guildID.IsValid() {
+		if member, err := m.chatView.state.Cabinet.Member(guildID, user.ID); err == nil {
+			if member.Nick != "" {
+				fmt.Fprintf(&b, "Nickname:     %s\n", member.Nick)
+			}
+			if member.Joined.IsValid() {
+				fmt.Fprintf(&b, "Joined:       %s\n", member.Joined.Time().Format("January 2, 2006"))
+			}
+			if len(member.RoleIDs) > 0 {
+				var roles []string
+				for _, roleID := range member.RoleIDs {
+					if role, err := m.chatView.state.Cabinet.Role(guildID, roleID); err == nil {
+						roles = append(roles, role.Name)
+					}
+				}
+				if len(roles) > 0 {
+					fmt.Fprintf(&b, "Roles:        %s\n", strings.Join(roles, ", "))
+				}
+			}
+		}
+	}
+
+	if note := m.chatView.state.NoteState.Note(user.ID); note != "" {
+		fmt.Fprintf(&b, "Note:         %s\n", note)
+	}
+
+	tv := tview.NewTextView().
+		SetText(b.String()).
+		SetScrollable(true).
+		SetWrap(true).
+		SetWordWrap(true)
+	tv.SetTitle("Profile — " + user.DisplayOrUsername())
+	tv.SetBorders(tview.BordersAll)
+
+	pv := &profileView{
+		TextView: tv,
+		close: func() {
+			m.chatView.RemoveLayer(profileLayerName)
+			m.chatView.app.SetFocus(previousFocus)
+		},
+	}
+
+	m.chatView.
+		AddLayer(
+			ui.Centered(pv, 60, 16),
+			layers.WithName(profileLayerName),
+			layers.WithResize(true),
+			layers.WithVisible(true),
+			layers.WithOverlay(),
+		).
+		SendToFront(profileLayerName)
+	m.chatView.app.SetFocus(pv)
+}
+
+// profileView wraps a TextView to intercept Escape for closing.
+type profileView struct {
+	*tview.TextView
+	close func()
+}
+
+func (p *profileView) InputHandler(event *tcell.EventKey, setFocus func(tview.Primitive)) {
+	if event.Key() == tcell.KeyEscape {
+		p.close()
+		return
+	}
+	p.TextView.InputHandler(event, setFocus)
+}
+
+// Help bar integration
+
+func (m *userContextMenu) ShortHelp() []keybind.Keybind {
+	binds := make([]keybind.Keybind, 0, len(m.items)+1)
+	for _, item := range m.items {
+		binds = append(binds, keybind.NewKeybind(
+			keybind.WithKeys(string(item.key)),
+			keybind.WithHelp(strings.ToLower(string(item.key)), item.label),
+		))
+	}
+	binds = append(binds, keybind.NewKeybind(
+		keybind.WithKeys("esc"),
+		keybind.WithHelp("esc", "cancel"),
+	))
+	return binds
+}
+
+func (m *userContextMenu) FullHelp() [][]keybind.Keybind {
+	return [][]keybind.Keybind{m.ShortHelp()}
+}

--- a/internal/ui/chat/user_context_menu.go
+++ b/internal/ui/chat/user_context_menu.go
@@ -129,7 +129,6 @@ func (m *userContextMenu) build(user discord.User, guildID discord.GuildID) {
 	})
 
 	m.SetCursor(-1)
-	m.MarkDirty()
 }
 
 // showAt displays the menu anchored near the given screen position. The menu
@@ -217,12 +216,12 @@ func (m *userContextMenu) handleInput(event *tcell.EventKey) *tcell.EventKey {
 	return nil
 }
 
-func (m *userContextMenu) InputHandler(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+func (m *userContextMenu) InputHandler(event *tcell.EventKey) tview.Command {
 	event = m.handleInput(event)
 	if event == nil {
-		return
+		return tview.BatchCommand{tview.RedrawCommand{}, tview.ConsumeEventCommand{}}
 	}
-	m.List.InputHandler(event, setFocus)
+	return m.List.InputHandler(event)
 }
 
 func (m *userContextMenu) hasExistingDM(userID discord.UserID) bool {
@@ -396,12 +395,12 @@ type profileView struct {
 	close func()
 }
 
-func (p *profileView) InputHandler(event *tcell.EventKey, setFocus func(tview.Primitive)) {
+func (p *profileView) InputHandler(event *tcell.EventKey) tview.Command {
 	if event.Key() == tcell.KeyEscape {
 		p.close()
-		return
+		return tview.BatchCommand{tview.RedrawCommand{}, tview.ConsumeEventCommand{}}
 	}
-	p.TextView.InputHandler(event, setFocus)
+	return p.TextView.InputHandler(event)
 }
 
 // Help bar integration

--- a/internal/ui/chat/view.go
+++ b/internal/ui/chat/view.go
@@ -36,11 +36,12 @@ type View struct {
 	mainFlex  *tview.Flex
 	rightFlex *tview.Flex
 
-	guildsTree     *guildsTree
-	messagesList   *messagesList
-	messageInput   *messageInput
-	channelsPicker *channelsPicker
-	help           *help.Help
+	guildsTree      *guildsTree
+	messagesList    *messagesList
+	messageInput    *messageInput
+	channelsPicker  *channelsPicker
+	userContextMenu *userContextMenu
+	help            *help.Help
 
 	selectedChannel   *discord.Channel
 	selectedChannelMu sync.RWMutex
@@ -74,6 +75,7 @@ func NewView(app *tview.Application, cfg *config.Config, onLogout func()) *View 
 	v.messagesList = newMessagesList(cfg, v)
 	v.messageInput = newMessageInput(cfg, v)
 	v.channelsPicker = newChannelsPicker(cfg, v)
+	v.userContextMenu = newUserContextMenu(cfg, v)
 	v.channelsPicker.SetCancelFunc(v.closePicker)
 
 	v.help = help.New()


### PR DESCRIPTION
## Summary
- Add a hotkey-driven user context menu triggered via `Ctrl+P` from the messages list or guilds tree (DM nodes only)
- Menu items: **Profile** (P), **Message** (M), and **Note** (N) — executed by pressing the highlighted letter
- Message option only shown for existing friends or DM channels to avoid Discord captcha issues
- Profile shows an overlay with user info (display name, username, ID, created date, roles, note)
- Note opens a form to view/edit the user's note

<img width="337" height="216" alt="CleanShot 2026-02-27 at 08 43 19" src="https://github.com/user-attachments/assets/3dcb653d-0785-4125-bc96-3ab29c4a1cb4" />

https://github.com/user-attachments/assets/c5747b0d-8e8e-42c7-9eb1-d5683cd76011

## Test plan
- [x] Build: `go build ./...`
- [x] Select a message in messages list, press `Ctrl+P` — menu appears anchored near the message
- [x] Select a DM channel in guilds tree, press `Ctrl+P` — menu appears for that DM user
- [x] Press `P` to view profile overlay, `Esc` to close
- [x] Press `N` to edit note, save/cancel works
- [x] Press `M` to open DM channel (only visible for friends/existing DMs)
- [x] Press `Esc` to dismiss menu
- [x] Verify help bar updates when menu is visible
- [x] Verify `Ctrl+P` on non-DM guilds tree nodes is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)