### PR TITLE
feat(ui/chat): split DM list into friends and others

### DIFF
--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -62,6 +62,18 @@ func Centered(p tview.Primitive, width, height int) tview.Primitive {
 		AddItem(p, 1, 1, 1, 1, 0, 0, true)
 }
 
+// IsFriendDM reports whether a DM channel is with a friend.
+// Group DMs always return true (they require an invite).
+func IsFriendDM(channel discord.Channel, state *ningen.State) bool {
+	if channel.Type == discord.GroupDM {
+		return true
+	}
+	if channel.Type != discord.DirectMessage || len(channel.DMRecipients) != 1 {
+		return true
+	}
+	return state.RelationshipState.RelationshipType(channel.DMRecipients[0].ID) == discord.FriendRelationship
+}
+
 func ChannelToString(channel discord.Channel, icons config.Icons, state *ningen.State) string {
 	var icon string
 	switch channel.Type {


### PR DESCRIPTION
## Summary
- Partition the Direct Messages folder into friend DMs and non-friend DMs
- Friend DMs (and group DMs) appear at the top as before
- Non-friend 1:1 DMs are grouped into a collapsed "Others (N)" folder at the bottom

## Details
Builds on #757. Adds an `IsFriendDM` helper that checks the relationship type via ningen's `RelationshipState`. The DM node's `onSelected` handler partitions channels into two lists and renders the "Others" folder as a lazy-loaded expandable node.

<img width="223" height="271" alt="CleanShot 2026-03-01 at 07 01 54" src="https://github.com/user-attachments/assets/8750cc74-41c3-42f2-8ffb-57ed0d6f9ec8" />

## Test plan
- [x] Build: `go build ./...`
- [x] Run discordo, expand Direct Messages — friend DMs appear at the top, non-friend DMs in a collapsed "Others" folder at the bottom
- [x] Expanding the "Others" folder shows non-friend DMs sorted by recent activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)