### PR TITLE
fix(ui/chat): allow opening channels that have threaded children

### DIFF
--- a/internal/ui/chat/channels_picker.go
+++ b/internal/ui/chat/channels_picker.go
@@ -50,8 +50,10 @@ func (cp *channelsPicker) Update(msg tview.Msg) tview.Cmd {
 		cp.chat.guildsTree.expandPathToNode(node)
 		cp.chat.guildsTree.SetCurrentNode(node)
 		var selectCmd tview.Cmd
-		if channel.Type != discord.GuildCategory {
+		if cp.chat.guildsTree.isContainerChannel(*channel) {
 			selectCmd = cp.chat.guildsTree.onSelected(node)
+		} else {
+			selectCmd = cp.chat.guildsTree.openChannelNode(node, *channel)
 		}
 		cp.chat.closePicker()
 		return selectCmd

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -60,26 +60,61 @@ func newGuildsTree(cfg *config.Config, chat *Model) *guildsTree {
 	return gt
 }
 
+func (gt *guildsTree) isContainerChannel(channel discord.Channel) bool {
+	switch channel.Type {
+	case discord.GuildCategory, discord.GuildForum:
+		return true
+	default:
+		return false
+	}
+}
+
+func (gt *guildsTree) isActiveChannel(channelID discord.ChannelID) bool {
+	selected := gt.chat.SelectedChannel()
+	return selected != nil && selected.ID == channelID
+}
+
+func (gt *guildsTree) selectActionDesc(node *tview.TreeNode, fallback string) string {
+	if node == nil {
+		return fallback
+	}
+
+	switch ref := node.GetReference().(type) {
+	case discord.GuildID, dmNode:
+		if len(node.GetChildren()) > 0 && node.IsExpanded() {
+			return "collapse"
+		}
+		return "expand"
+	case discord.ChannelID:
+		channel, err := gt.chat.state.Cabinet.Channel(ref)
+		if err != nil {
+			return fallback
+		}
+
+		if gt.isContainerChannel(*channel) {
+			if len(node.GetChildren()) > 0 && node.IsExpanded() {
+				return "collapse"
+			}
+			return "expand"
+		}
+
+		if len(node.GetChildren()) > 0 && gt.isActiveChannel(channel.ID) {
+			if node.IsExpanded() {
+				return "collapse"
+			}
+			return "expand"
+		}
+	}
+
+	return fallback
+}
+
 func (gt *guildsTree) ShortHelp() []keybind.Keybind {
 	cfg := gt.cfg.Keybinds.GuildsTree
 	selectCurrent := cfg.SelectCurrent.Keybind
 	collapseParent := cfg.CollapseParentNode.Keybind
 	selectHelp := selectCurrent.Help()
-	selectDesc := selectHelp.Desc
-	if node := gt.GetCurrentNode(); node != nil {
-		if len(node.GetChildren()) > 0 {
-			if node.IsExpanded() {
-				selectDesc = "collapse"
-			} else {
-				selectDesc = "expand"
-			}
-		} else {
-			switch node.GetReference().(type) {
-			case discord.GuildID, dmNode:
-				selectDesc = "expand"
-			}
-		}
-	}
+	selectDesc := gt.selectActionDesc(gt.GetCurrentNode(), selectHelp.Desc)
 	selectCurrent.SetHelp(selectHelp.Key, selectDesc)
 	collapseHelp := collapseParent.Help()
 	collapseParent.SetHelp(collapseHelp.Key, "collapse parent")
@@ -96,21 +131,7 @@ func (gt *guildsTree) FullHelp() [][]keybind.Keybind {
 	selectCurrent := cfg.SelectCurrent.Keybind
 	collapseParent := cfg.CollapseParentNode.Keybind
 	selectHelp := selectCurrent.Help()
-	selectDesc := selectHelp.Desc
-	if node := gt.GetCurrentNode(); node != nil {
-		if len(node.GetChildren()) > 0 {
-			if node.IsExpanded() {
-				selectDesc = "collapse"
-			} else {
-				selectDesc = "expand"
-			}
-		} else {
-			switch node.GetReference().(type) {
-			case discord.GuildID, dmNode:
-				selectDesc = "expand"
-			}
-		}
-	}
+	selectDesc := gt.selectActionDesc(gt.GetCurrentNode(), selectHelp.Desc)
 	selectCurrent.SetHelp(selectHelp.Key, selectDesc)
 	collapseHelp := collapseParent.Help()
 	collapseParent.SetHelp(collapseHelp.Key, "collapse parent")
@@ -299,9 +320,13 @@ func (gt *guildsTree) createChannelNodes(node *tview.TreeNode, channels []discor
 	}
 }
 
-func (gt *guildsTree) onSelected(node *tview.TreeNode) tview.Cmd {
+func (gt *guildsTree) toggleNode(node *tview.TreeNode) {
+	node.SetExpanded(!node.IsExpanded())
+}
+
+func (gt *guildsTree) selectLazyContainerNode(node *tview.TreeNode) tview.Cmd {
 	if len(node.GetChildren()) != 0 {
-		node.SetExpanded(!node.IsExpanded())
+		gt.toggleNode(node)
 		return nil
 	}
 
@@ -318,42 +343,6 @@ func (gt *guildsTree) onSelected(node *tview.TreeNode) tview.Cmd {
 		ui.SortGuildChannels(channels)
 		gt.createChannelNodes(node, channels)
 		node.Expand()
-		return nil
-	case discord.ChannelID:
-		channel, err := gt.chat.state.Cabinet.Channel(ref)
-		if err != nil {
-			slog.Error("failed to get channel from state", "err", err, "channel_id", ref)
-			return nil
-		}
-
-		// Handle forum channels differently - they contain threads, not direct messages
-		if channel.Type == discord.GuildForum {
-			// Get all channels from the guild - this includes active threads from GuildCreateEvent
-			allChannels, err := gt.chat.state.Cabinet.Channels(channel.GuildID)
-			if err != nil {
-				slog.Error("failed to get channels for forum threads", "err", err, "guild_id", channel.GuildID)
-				return nil
-			}
-
-			// Filter for threads that belong to this forum channel
-			var forumThreads []discord.Channel
-			for _, ch := range allChannels {
-				if ch.ParentID == channel.ID && (ch.Type == discord.GuildPublicThread ||
-					ch.Type == discord.GuildPrivateThread ||
-					ch.Type == discord.GuildAnnouncementThread) {
-					forumThreads = append(forumThreads, ch)
-				}
-			}
-
-			// Add threads as child nodes
-			for _, thread := range forumThreads {
-				gt.createChannelNode(node, thread)
-			}
-			node.Expand()
-			return nil
-		}
-
-		return gt.loadChannel(*channel)
 	case dmNode: // Direct messages folder
 		channels, err := gt.chat.state.PrivateChannels()
 		if err != nil {
@@ -366,7 +355,74 @@ func (gt *guildsTree) onSelected(node *tview.TreeNode) tview.Cmd {
 			gt.createChannelNode(node, c)
 		}
 		node.Expand()
+	}
+
+	return nil
+}
+
+func (gt *guildsTree) selectForumNode(node *tview.TreeNode, channel discord.Channel) tview.Cmd {
+	if len(node.GetChildren()) != 0 {
+		gt.toggleNode(node)
 		return nil
+	}
+
+	// Get all channels from the guild - this includes active threads from GuildCreateEvent.
+	allChannels, err := gt.chat.state.Cabinet.Channels(channel.GuildID)
+	if err != nil {
+		slog.Error("failed to get channels for forum threads", "err", err, "guild_id", channel.GuildID)
+		return nil
+	}
+
+	for _, ch := range allChannels {
+		if ch.ParentID != channel.ID {
+			continue
+		}
+		switch ch.Type {
+		case discord.GuildPublicThread, discord.GuildPrivateThread, discord.GuildAnnouncementThread:
+			if gt.channelNodeByID[ch.ID] == nil {
+				gt.createChannelNode(node, ch)
+			}
+		}
+	}
+	node.Expand()
+	return nil
+}
+
+func (gt *guildsTree) openChannelNode(node *tview.TreeNode, channel discord.Channel) tview.Cmd {
+	if len(node.GetChildren()) != 0 {
+		node.Expand()
+	}
+
+	return gt.loadChannel(channel)
+}
+
+func (gt *guildsTree) onSelected(node *tview.TreeNode) tview.Cmd {
+	switch ref := node.GetReference().(type) {
+	case discord.GuildID, dmNode:
+		return gt.selectLazyContainerNode(node)
+	case discord.ChannelID:
+		channel, err := gt.chat.state.Cabinet.Channel(ref)
+		if err != nil {
+			slog.Error("failed to get channel from state", "err", err, "channel_id", ref)
+			return nil
+		}
+
+		switch channel.Type {
+		case discord.GuildCategory:
+			gt.toggleNode(node)
+			return nil
+		case discord.GuildForum:
+			return gt.selectForumNode(node, *channel)
+		}
+
+		// Re-selecting the already-open parent channel uses Enter to toggle its
+		// thread children; otherwise Enter opens the channel itself.
+		if len(node.GetChildren()) != 0 && gt.isActiveChannel(channel.ID) {
+			gt.toggleNode(node)
+			return nil
+		}
+
+		return gt.openChannelNode(node, *channel)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
The `onSelected` handler in the guilds tree determined behaviour based on whether a node had children: nodes with children were toggled, nodes without were opened.
This broke channel selection for channels with threads. Pressing Enter would toggle visibility of the node's child threads instead of opening the channel.
This issue was also present in the channels picker so there was no way at all to select channels if they had child threads.
Fixes #309 

## Changes
- Refactored `onSelected` to dispatch by node/channel type rather than by presence of children. Guilds, DMs, categories, and forums expand/collapse as before, regular channels are opened when first selected and child threads are toggled when re-selecting the already-active channel.
- Fixed the same issue in the channels picker.
- Updated help bar text to accurately reflect the action Enter will take on each node type.

## Preview
![discordo](https://github.com/user-attachments/assets/64255943-c566-4b36-ad96-ffd381bbbe8f)
