### PR TITLE
feat(chat): add guild tree scroll keybinds

### DIFF
--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -122,6 +122,9 @@ up = "k"
 down = "j"
 top = "g"
 bottom = "G"
+# Move the highlighted guild tree item by page.
+select_page_up = "K"
+select_page_down = "J"
 # Select the currently highlighted text-based channel or expand a guild or channel.
 select_current = "enter"
 yank_id = "i"

--- a/internal/config/keybinds.go
+++ b/internal/config/keybinds.go
@@ -59,6 +59,8 @@ type SelectionKeybinds struct {
 	SelectDown   Keybind `toml:"select_down"`
 	SelectTop    Keybind `toml:"select_top"`
 	SelectBottom Keybind `toml:"select_bottom"`
+	SelectPageUp   Keybind `toml:"select_page_up"`
+	SelectPageDown Keybind `toml:"select_page_down"`
 }
 
 type PickerKeybinds struct {
@@ -69,6 +71,7 @@ type PickerKeybinds struct {
 
 type GuildsTreeKeybinds struct {
 	NavigationKeybinds
+	SelectionKeybinds
 	SelectCurrent Keybind `toml:"select_current"`
 	YankID        Keybind `toml:"yank_id"`
 
@@ -159,6 +162,10 @@ func defaultNavigationKeybinds() NavigationKeybinds {
 func defaultGuildsTreeKeybinds() GuildsTreeKeybinds {
 	return GuildsTreeKeybinds{
 		NavigationKeybinds: defaultNavigationKeybinds(),
+		SelectionKeybinds: SelectionKeybinds{
+			SelectPageUp:   newKeybind("K", "page up"),
+			SelectPageDown: newKeybind("J", "page down"),
+		},
 		SelectCurrent:      newKeybind("enter", "select"),
 		YankID:             newKeybind("i", "copy id"),
 

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -339,6 +339,10 @@ func (gt *guildsTree) Update(msg tview.Msg) tview.Cmd {
 			return nil
 		case keybind.Matches(msg, gt.cfg.Keybinds.GuildsTree.MoveToParentNode.Keybind):
 			return handler(tcell.NewEventKey(tcell.KeyRune, "K", tcell.ModNone))
+		case keybind.Matches(msg, gt.cfg.Keybinds.GuildsTree.SelectionKeybinds.SelectPageUp.Keybind):
+			return handler(tcell.NewEventKey(tcell.KeyPgUp, "", tcell.ModNone))
+		case keybind.Matches(msg, gt.cfg.Keybinds.GuildsTree.SelectionKeybinds.SelectPageDown.Keybind):
+			return handler(tcell.NewEventKey(tcell.KeyPgDn, "", tcell.ModNone))
 		case keybind.Matches(msg, gt.cfg.Keybinds.GuildsTree.Up.Keybind):
 			return handler(tcell.NewEventKey(tcell.KeyUp, "", tcell.ModNone))
 		case keybind.Matches(msg, gt.cfg.Keybinds.GuildsTree.Down.Keybind):
@@ -489,6 +493,7 @@ func (gt *guildsTree) FullHelp() [][]keybind.Keybind {
 
 	return [][]keybind.Keybind{
 		{cfg.Up.Keybind, cfg.Down.Keybind, cfg.Top.Keybind, cfg.Bottom.Keybind},
+		{cfg.SelectionKeybinds.SelectPageUp.Keybind, cfg.SelectionKeybinds.SelectPageDown.Keybind},
 		selectGroup,
 		{cfg.YankID.Keybind},
 	}


### PR DESCRIPTION
## Summary
- Add scroll keybinds to the guilds tree
- Wire them to page navigation and show them in help
- Document the defaults in config