### PR TITLE
fix(ui/chat): show live threads and open channels that have them

### DIFF
--- a/internal/ui/chat/channelspicker/model.go
+++ b/internal/ui/chat/channelspicker/model.go
@@ -70,6 +70,10 @@ func (m *Model) RefreshChannels(state *ningen.State) {
 		}
 
 		for _, channel := range channels {
+			switch channel.Type {
+			case discord.GuildPublicThread, discord.GuildPrivateThread, discord.GuildAnnouncementThread:
+				continue
+			}
 			items = append(items, m.channelItem(state, &guild, channel))
 		}
 	}

--- a/internal/ui/chat/guilds_tree.go
+++ b/internal/ui/chat/guilds_tree.go
@@ -128,6 +128,11 @@ func (gt *guildsTree) guildNodeStyle(guildID discord.GuildID) tcell.Style {
 }
 
 func (gt *guildsTree) channelNodeStyle(channel discord.Channel) tcell.Style {
+	if isThread(channel.Type) && channel.ParentID.IsValid() {
+		if parent, err := gt.state.Cabinet.Channel(channel.ParentID); err == nil {
+			return gt.unreadStyle(gt.state.ChannelIsUnread(parent.ID, ningen.UnreadOpts{IncludeMutedCategories: true}))
+		}
+	}
 	unread := gt.unreadStyle(gt.state.ChannelIsUnread(channel.ID, ningen.UnreadOpts{IncludeMutedCategories: true}))
 	if channel.Type != discord.DirectMessage || len(channel.DMRecipients) != 1 {
 		return unread
@@ -167,7 +172,11 @@ func (gt *guildsTree) createGuildNode(parent *tree.Node, guild discord.Guild) {
 }
 
 func (gt *guildsTree) createChannelNode(parent *tree.Node, channel discord.Channel) {
-	if channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && channel.Type != discord.GuildCategory && !gt.state.HasPermissions(channel.ID, discord.PermissionViewChannel) {
+	if isThread(channel.Type) {
+		if channel.ThreadMetadata != nil && channel.ThreadMetadata.Archived {
+			return
+		}
+	} else if channel.Type != discord.DirectMessage && channel.Type != discord.GroupDM && channel.Type != discord.GuildCategory && !gt.state.HasPermissions(channel.ID, discord.PermissionViewChannel) {
 		return
 	}
 
@@ -250,7 +259,7 @@ func isThread(t discord.ChannelType) bool {
 }
 
 func (gt *guildsTree) onSelected(node *tree.Node) tview.Cmd {
-	if len(node.Children()) != 0 {
+	if node.Expandable() && len(node.Children()) != 0 {
 		node.SetExpanded(!node.Expanded())
 		return nil
 	}

--- a/internal/ui/chat/model.go
+++ b/internal/ui/chat/model.go
@@ -318,6 +318,15 @@ func (m *Model) Update(msg tview.Msg) tview.Cmd {
 				m.onTypingStart(eventMsg)
 			}
 
+		case *gateway.ThreadCreateEvent:
+			m.onThreadCreate(eventMsg.Channel)
+		case *gateway.ThreadUpdateEvent:
+			m.onThreadUpdate(eventMsg.Channel)
+		case *gateway.ThreadDeleteEvent:
+			m.onThreadDelete(*eventMsg)
+		case *gateway.ThreadListSyncEvent:
+			m.onThreadListSync(eventMsg)
+
 		case *read.UpdateEvent:
 			m.onReadUpdate(eventMsg)
 		}

--- a/internal/ui/chat/state.go
+++ b/internal/ui/chat/state.go
@@ -244,6 +244,69 @@ func (m *Model) onTypingStart(event *gateway.TypingStartEvent) {
 	m.addTyper(event.UserID)
 }
 
+func (m *Model) onThreadCreate(thread discord.Channel) {
+	if !isThread(thread.Type) {
+		return
+	}
+	if thread.ParentID.IsValid() {
+		if parentNode := m.guildsTree.findNodeByReference(thread.ParentID); parentNode != nil {
+			m.guildsTree.createChannelNode(parentNode, thread)
+		}
+	}
+}
+
+func (m *Model) onThreadUpdate(thread discord.Channel) {
+	if !isThread(thread.Type) {
+		return
+	}
+	if node := m.guildsTree.findNodeByReference(thread.ID); node != nil {
+		if thread.ThreadMetadata != nil && thread.ThreadMetadata.Archived {
+			if parentNode := m.guildsTree.findNodeByReference(thread.ParentID); parentNode != nil {
+				parentNode.RemoveChild(node)
+			}
+			delete(m.guildsTree.channelNodeByID, thread.ID)
+		} else {
+			m.guildsTree.setNodeLineStyle(node, m.guildsTree.channelNodeStyle(thread))
+		}
+	}
+}
+
+func (m *Model) onThreadDelete(thread gateway.ThreadDeleteEvent) {
+	if node := m.guildsTree.findNodeByReference(thread.ID); node != nil {
+		if parentNode := m.guildsTree.findNodeByReference(thread.ParentID); parentNode != nil {
+			parentNode.RemoveChild(node)
+		}
+		delete(m.guildsTree.channelNodeByID, thread.ID)
+	}
+}
+
+func (m *Model) onThreadListSync(event *gateway.ThreadListSyncEvent) {
+	parents := make(map[discord.ChannelID]struct{}, len(event.ChannelIDs))
+	for _, id := range event.ChannelIDs {
+		parents[id] = struct{}{}
+	}
+
+	for _, thread := range event.Threads {
+		if !isThread(thread.Type) || !thread.ParentID.IsValid() {
+			continue
+		}
+		if len(parents) != 0 {
+			if _, ok := parents[thread.ParentID]; !ok {
+				continue
+			}
+		}
+
+		parentNode := m.guildsTree.findNodeByReference(thread.ParentID)
+		if parentNode == nil {
+			continue
+		}
+		if old := m.guildsTree.findNodeByReference(thread.ID); old != nil {
+			parentNode.RemoveChild(old)
+		}
+		m.guildsTree.createChannelNode(parentNode, thread)
+	}
+}
+
 func (m *Model) onReadUpdate(event *read.UpdateEvent) {
 	// Use indexed node lookup to avoid walking the whole tree on every read event.
 	// This runs frequently while reading/typing across channels.


### PR DESCRIPTION
Fixes #309

- `onSelected` toggles by expandability+loaded instead of raw child count, so a channel holding synced thread children still opens on Enter
- handle THREAD_CREATE / THREAD_UPDATE / THREAD_DELETE / THREAD_LIST_SYNC: insert, restyle, archive-remove, and de-duplicating re-sync of thread nodes under their parent channel
- skip the ViewChannel permission gate for threads (`CalcOverrides` reads the thread's own empty overwrites, not the parent's) and drop archived threads
- channels picker: hide thread entries